### PR TITLE
Maintenance/refactor static attributes

### DIFF
--- a/.pytest-ci.ini
+++ b/.pytest-ci.ini
@@ -5,6 +5,7 @@ addopts =
     --strict-markers
     --durations=50
     --durations-min=0.5
+    --disable-warnings
 markers =
     slow
     optional_dependency

--- a/.pytest.ini
+++ b/.pytest.ini
@@ -6,6 +6,7 @@ addopts =
     -m "not slow"
     --durations=50
     --durations-min=0.5
+    --disable-warnings
 markers =
     slow
     optional_dependency

--- a/mikeio1d/result_network/result_catchment.py
+++ b/mikeio1d/result_network/result_catchment.py
@@ -72,9 +72,9 @@ class ResultCatchment(ResultLocation):
 
     def set_static_attributes(self):
         """Set static attributes. These show up in the html repr."""
-        self.set_static_attribute("id", self._catchment.Id)
-        self.set_static_attribute("area", self._catchment.Area)
-        self.set_static_attribute("type", self._catchment.Type)
+        self.set_static_attribute("id")
+        self.set_static_attribute("area")
+        self.set_static_attribute("type")
 
     def add_to_result_quantity_maps(self, quantity_id, result_quantity):
         """Add catchment result quantity to result quantity maps."""
@@ -91,6 +91,21 @@ class ResultCatchment(ResultLocation):
         catchment_id = self._catchment.Id
         query = QueryDataCatchment(quantity_id, catchment_id)
         return query
+
+    @property
+    def id(self) -> str:
+        """The ID of the catchment."""
+        return self._catchment.Id
+
+    @property
+    def area(self) -> float:
+        """The area of the catchment."""
+        return self._catchment.Area
+
+    @property
+    def type(self) -> str:
+        """The type of the catchment."""
+        return self._catchment.Type
 
     @property
     def geometry(self) -> CatchmentGeometry:

--- a/mikeio1d/result_network/result_gridpoint.py
+++ b/mikeio1d/result_network/result_gridpoint.py
@@ -45,11 +45,11 @@ class ResultGridPoint(ResultLocation):
 
     def set_static_attributes(self):
         """Set static attributes. These show up in the html repr."""
-        self.set_static_attribute("reach_name", self.reach.Name)
-        self.set_static_attribute("chainage", self.gridpoint.Chainage)
-        self.set_static_attribute("xcoord", self.gridpoint.X)
-        self.set_static_attribute("ycoord", self.gridpoint.Y)
-        self.set_static_attribute("bottom_level", self.gridpoint.Z)
+        self.set_static_attribute("reach_name")
+        self.set_static_attribute("chainage")
+        self.set_static_attribute("xcoord")
+        self.set_static_attribute("ycoord")
+        self.set_static_attribute("bottom_level")
 
     def get_m1d_dataset(self, m1d_dataitem=None):
         """Get IRes1DDataSet object associated with ResultGridPoint.
@@ -98,3 +98,28 @@ class ResultGridPoint(ResultLocation):
     def add_structure_data_item(self, data_item):
         """Add data item to structure data items list."""
         self.structure_data_items.append(data_item)
+
+    @property
+    def reach_name(self):
+        """Name of reach the gridpoint is on."""
+        return self.reach.Name
+
+    @property
+    def chainage(self):
+        """Chainage of the gridpoint."""
+        return self.gridpoint.Chainage
+
+    @property
+    def xcoord(self):
+        """X coordinate of the gridpoint."""
+        return self.gridpoint.X
+
+    @property
+    def ycoord(self):
+        """Y coordinate of the gridpoint."""
+        return self.gridpoint.Y
+
+    @property
+    def bottom_level(self):
+        """Bottom level of the gridpoint."""
+        return self.gridpoint.Z

--- a/mikeio1d/result_network/result_location.py
+++ b/mikeio1d/result_network/result_location.py
@@ -117,10 +117,9 @@ class ResultLocation(ABC):
         """A list of available derived quantities."""
         return list(self.result_quantity_derived_map.keys())
 
-    def set_static_attribute(self, key, value):
+    def set_static_attribute(self, name: str):
         """Add static attribute. This shows up in the html repr."""
-        self._static_attributes.append(key)
-        setattr(self, key, value)
+        self._static_attributes.append(name)
 
     def set_quantities(self):
         """Set all quantity attributes."""

--- a/mikeio1d/result_network/result_node.py
+++ b/mikeio1d/result_network/result_node.py
@@ -69,21 +69,14 @@ class ResultNode(ResultLocation):
 
     def set_static_attributes(self):
         """Set static attributes. These show up in the html repr."""
-        self._static_attributes = []
-
-        node_type = self._node.GetType().Name[5:]  # Removes 'Res1D' from type name
-        self.set_static_attribute("id", self._node.Id)
-        self.set_static_attribute("type", node_type)
-        self.set_static_attribute("xcoord", self._node.XCoordinate)
-        self.set_static_attribute("ycoord", self._node.YCoordinate)
-
-        # Collect attributes depending on node type
-        if self.type in ["Basin", "Manhole", "SewerJunction"]:
-            self.set_static_attribute("ground_level", self._node.GroundLevel)
-            self.set_static_attribute("bottom_level", self._node.BottomLevel)
-            self.set_static_attribute("critical_level", self._node.CriticalLevel)
-        if self.type == "Manhole":
-            self.set_static_attribute("diameter", self._node.Diameter)
+        self.set_static_attribute("id")
+        self.set_static_attribute("type")
+        self.set_static_attribute("xcoord")
+        self.set_static_attribute("ycoord")
+        self.set_static_attribute("ground_level")
+        self.set_static_attribute("bottom_level")
+        self.set_static_attribute("critical_level")
+        self.set_static_attribute("diameter")
 
     def add_to_result_quantity_maps(self, quantity_id, result_quantity):
         """Add node result quantity to result quantity maps."""
@@ -108,3 +101,76 @@ class ResultNode(ResultLocation):
         from ..geometry import NodePoint
 
         return NodePoint.from_res1d_node(self._node)
+
+    @property
+    def id(self) -> str:
+        """Node ID."""
+        return self._node.ID
+
+    @property
+    def type(self) -> str:
+        """Node type."""
+        node_type = self._node.GetType().Name[5:]  # Removes 'Res1D' from type name
+        return node_type
+
+    @property
+    def xcoord(self) -> float:
+        """X coordinate of the node."""
+        return self._node.XCoordinate
+
+    @property
+    def ycoord(self) -> float:
+        """Y coordinate of the node."""
+        return self._node.YCoordinate
+
+    @property
+    def ground_level(self) -> float | None:
+        """Ground level of the node.
+
+        Returns
+        -------
+            float: Ground level of the node.
+            None: If the node does not have a ground level.
+        """
+        if hasattr(self._node, "GroundLevel"):
+            return self._node.GroundLevel
+        return None
+
+    @property
+    def bottom_level(self) -> float | None:
+        """Bottom level of the node.
+
+        Returns
+        -------
+            float: Bottom level of the node.
+            None: If the node does not have a bottom level.
+        """
+        if hasattr(self._node, "BottomLevel"):
+            return self._node.BottomLevel
+        return None
+
+    @property
+    def critical_level(self) -> float | None:
+        """Critical level of the node.
+
+        Returns
+        -------
+            float: Critical level of the node.
+            None: If the node does not have a critical level.
+        """
+        if hasattr(self._node, "CriticalLevel"):
+            return self._node.CriticalLevel
+        return None
+
+    @property
+    def diameter(self) -> float | None:
+        """Diameter of the node.
+
+        Returns
+        -------
+            float: Diameter of the node.
+            None: If the node does not have a diameter.
+        """
+        if hasattr(self._node, "Diameter"):
+            return self._node.Diameter
+        return None

--- a/mikeio1d/result_network/result_structure.py
+++ b/mikeio1d/result_network/result_structure.py
@@ -38,9 +38,9 @@ class ResultStructure(ResultLocation):
         self._group = TimeSeriesIdGroup.STRUCTURE
         self._name = structure_id
         self._tag = reach.Name
-        self.id = structure_id
+        self._id = structure_id
         self.reach = reach
-        self.chainage = None
+        self._chainage = None
 
         self.data_items_dict = {}
         for data_item in data_items:
@@ -82,10 +82,9 @@ class ResultStructure(ResultLocation):
 
     def set_static_attributes(self):
         """Set static attributes. These show up in the html repr."""
-        self._static_attributes = []
-        self.set_static_attribute("id", self.id)
-        self.set_static_attribute("type", self.reach.Name.split(":")[0])
-        self.set_static_attribute("chainage", self.chainage)
+        self.set_static_attribute("id")
+        self.set_static_attribute("type")
+        self.set_static_attribute("chainage")
 
     def add_to_result_quantity_maps(self, quantity_id, result_quantity):
         """Add structure result quantity to result quantity maps."""
@@ -105,11 +104,11 @@ class ResultStructure(ResultLocation):
             A MIKE 1D IDataItem object.
 
         """
-        if self.chainage is None:
+        if self._chainage is None:
             index_list = list(data_item.IndexList)
             gridpoint_index = index_list[0]
             gridpoints = list(self.reach.GridPoints)
-            self.chainage = gridpoints[gridpoint_index].Chainage
+            self._chainage = gridpoints[gridpoint_index].Chainage
 
         self.data_items.append(data_item)
         self.data_items_dict[data_item.Quantity.Id] = data_item
@@ -137,5 +136,20 @@ class ResultStructure(ResultLocation):
         """Get a QueryDataStructure for given data item."""
         quantity_id = data_item.Quantity.Id
         structure_id = self.id
-        query = QueryDataStructure(quantity_id, structure_id, self.reach.Name, self.chainage)
+        query = QueryDataStructure(quantity_id, structure_id, self.reach.Name, self._chainage)
         return query
+
+    @property
+    def id(self) -> str:
+        """Structure ID."""
+        return self._id
+
+    @property
+    def type(self) -> str:
+        """Type of the structure."""
+        return self.reach.Name.split(":")[0]
+
+    @property
+    def chainage(self) -> float:
+        """Chainage of the structure."""
+        return self._chainage


### PR DESCRIPTION
Static attributes at result locations are currently set at runtime with `setattr`. This PR refactors that so that each static attribute exists as a python property.