### PR TITLE
Extract ResultLocation creation and handling code to ResultLocationCreator.

### DIFF
--- a/mikeio1d/geometry/geopandas/geopandas_catchments_converter.py
+++ b/mikeio1d/geometry/geopandas/geopandas_catchments_converter.py
@@ -35,7 +35,7 @@ class GeoPandasCatchmentsConverter(GeoPandasConverter):
         """Create a dictionary with the data needed to create a GeoDataFrame."""
         names = [catchment.id for catchment in catchments.values()]
         geometries = [
-            CatchmentGeometry.from_res1d_catchment(catchment._catchment).to_shapely()
+            CatchmentGeometry.from_res1d_catchment(catchment.catchment).to_shapely()
             for catchment in catchments.values()
         ]
         data = {

--- a/mikeio1d/geometry/geopandas/geopandas_catchments_converter.py
+++ b/mikeio1d/geometry/geopandas/geopandas_catchments_converter.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover
     from geopandas import GeoDataFrame
 
-    from result_network import ResultCatchments
+    from ...result_network import ResultCatchments
 
 from geopandas import GeoDataFrame
 

--- a/mikeio1d/geometry/geopandas/geopandas_nodes_converter.py
+++ b/mikeio1d/geometry/geopandas/geopandas_nodes_converter.py
@@ -34,7 +34,7 @@ class GeoPandasNodesConverter(GeoPandasConverter):
     def _create_dataframe_data_dict(self, nodes: ResultNodes) -> dict[str, tuple]:
         """Create a dictionary with the data needed to create a GeoDataFrame."""
         names = [node.id for node in nodes.values()]
-        geometries = [NodePoint.from_res1d_node(node._node).to_shapely() for node in nodes.values()]
+        geometries = [NodePoint.from_res1d_node(node.node).to_shapely() for node in nodes.values()]
         data = {
             "group": TimeSeriesIdGroup.NODE,
             "name": names,

--- a/mikeio1d/geometry/geopandas/geopandas_nodes_converter.py
+++ b/mikeio1d/geometry/geopandas/geopandas_nodes_converter.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:  # pragma: no cover
     from geopandas import GeoDataFrame
 
-    from result_network import ResultNodes
+    from ...result_network import ResultNodes
 
 from geopandas import GeoDataFrame
 

--- a/mikeio1d/quantities/derived/derived_quantity.py
+++ b/mikeio1d/quantities/derived/derived_quantity.py
@@ -202,6 +202,6 @@ class DerivedQuantity(ABC):
         if self.source_quantity not in result_location.quantities:
             return []
 
-        result_quantities = result_location.result_quantity_map[self.source_quantity]
+        result_quantities = result_location._creator.result_quantity_map[self.source_quantity]
         tsids = [q.timeseries_id for q in result_quantities]
         return tsids

--- a/mikeio1d/res1d.py
+++ b/mikeio1d/res1d.py
@@ -24,6 +24,10 @@ if TYPE_CHECKING:  # pragma: no cover
     from .result_network import ResultStructures
     from .result_network import ResultGlobalDatas
 
+    from DHI.Mike1D.ResultDataAccess import ResultData
+    from DHI.Mike1D.ResultDataAccess import ResultDataSearcher
+    from DHI.Mike1D.ResultDataAccess import ResultDataQuery
+
 import os.path
 import warnings
 
@@ -527,7 +531,7 @@ class Res1D:
         return self.reader.file_path
 
     @property
-    def query(self):
+    def query(self) -> ResultDataQuery:
         """.NET object ResultDataQuery to use for querying the loaded res1d data.
 
         More information about ResultDataQuery class see:
@@ -536,7 +540,7 @@ class Res1D:
         return self.reader.query
 
     @property
-    def searcher(self):
+    def searcher(self) -> ResultDataSearcher:
         """.NET object ResultDataSearcher to use for searching res1d data items on network.
 
         More information about ResultDataSearcher class see:
@@ -545,7 +549,7 @@ class Res1D:
         return self.reader.searcher
 
     @property
-    def data(self):
+    def data(self) -> ResultData:
         """.NET object ResultData with the loaded res1d data.
 
         More information about ResultData class see:
@@ -554,7 +558,7 @@ class Res1D:
         return self.reader.data
 
     @property
-    def projection_string(self):
+    def projection_string(self) -> str:
         """Projection string of the result file."""
         return self.data.ProjectionString
 

--- a/mikeio1d/res1d.py
+++ b/mikeio1d/res1d.py
@@ -33,7 +33,6 @@ import warnings
 
 from pathlib import Path
 
-
 from .dotnet import from_dotnet_datetime
 from .dotnet import to_dotnet_datetime
 from .dotnet import to_numpy

--- a/mikeio1d/result_network/result_catchment.py
+++ b/mikeio1d/result_network/result_catchment.py
@@ -57,29 +57,6 @@ class ResultCatchment(ResultLocation):
         else:
             object.__getattribute__(self, name)
 
-    def get_m1d_dataset(self, m1d_dataitem=None):
-        """Get IRes1DDataSet object associated with ResultCatchment.
-
-        Parameters
-        ----------
-        m1d_dataitem: IDataItem, optional
-            Ignored for ResultCatchment.
-
-        Returns
-        -------
-        IRes1DDataSet
-            IRes1DDataSet object associated with ResultCatchment.
-
-        """
-        return self.catchment
-
-    def get_query(self, data_item):
-        """Get a QueryDataCatchment for given data item."""
-        quantity_id = data_item.Quantity.Id
-        catchment_id = self.catchment.Id
-        query = QueryDataCatchment(quantity_id, catchment_id)
-        return query
-
     @property
     def catchment(self) -> IRes1DCatchment:
         """IRes1DCatchment corresponding to this result location."""
@@ -108,6 +85,29 @@ class ResultCatchment(ResultLocation):
         from ..geometry import CatchmentGeometry
 
         return CatchmentGeometry.from_res1d_catchment(self.catchment)
+
+    def get_m1d_dataset(self, m1d_dataitem=None):
+        """Get IRes1DDataSet object associated with ResultCatchment.
+
+        Parameters
+        ----------
+        m1d_dataitem: IDataItem, optional
+            Ignored for ResultCatchment.
+
+        Returns
+        -------
+        IRes1DDataSet
+            IRes1DDataSet object associated with ResultCatchment.
+
+        """
+        return self.catchment
+
+    def get_query(self, data_item):
+        """Get a QueryDataCatchment for given data item."""
+        quantity_id = data_item.Quantity.Id
+        catchment_id = self.catchment.Id
+        query = QueryDataCatchment(quantity_id, catchment_id)
+        return query
 
 
 class ResultCatchmentCreator(ResultLocationCreator):

--- a/mikeio1d/result_network/result_catchment.py
+++ b/mikeio1d/result_network/result_catchment.py
@@ -5,7 +5,11 @@ from warnings import warn
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
+    from ..res1d import Res1D
     from ..geometry import CatchmentGeometry
+    from .result_quantity import ResultQuantity
+
+    from DHI.Mike1D.ResultDataAccess import IDataItem
     from DHI.Mike1D.ResultDataAccess import IRes1DCatchment
 
 from ..query import QueryDataCatchment
@@ -27,7 +31,7 @@ class ResultCatchment(ResultLocation):
         Res1D object the catchment belongs to.
     """
 
-    def __init__(self, catchment, res1d):
+    def __init__(self, catchment: IRes1DCatchment, res1d: Res1D):
         ResultLocation.__init__(self)
 
         self._group = TimeSeriesIdGroup.CATCHMENT
@@ -86,7 +90,7 @@ class ResultCatchment(ResultLocation):
 
         return CatchmentGeometry.from_res1d_catchment(self.catchment)
 
-    def get_m1d_dataset(self, m1d_dataitem=None):
+    def get_m1d_dataset(self, m1d_dataitem: IDataItem = None) -> IRes1DCatchment:
         """Get IRes1DDataSet object associated with ResultCatchment.
 
         Parameters
@@ -102,7 +106,7 @@ class ResultCatchment(ResultLocation):
         """
         return self.catchment
 
-    def get_query(self, data_item):
+    def get_query(self, data_item: IDataItem) -> QueryDataCatchment:
         """Get a QueryDataCatchment for given data item."""
         quantity_id = data_item.Quantity.Id
         catchment_id = self.catchment.Id
@@ -124,9 +128,14 @@ class ResultCatchmentCreator(ResultLocationCreator):
 
     """
 
-    def __init__(self, result_location, catchment, res1d):
+    def __init__(
+        self,
+        result_location: ResultCatchment,
+        catchment: IRes1DCatchment,
+        res1d: Res1D,
+    ):
         ResultLocationCreator.__init__(self, result_location, catchment.DataItems, res1d)
-        self.catchment = catchment
+        self.catchment: IRes1DCatchment = catchment
 
     def create(self):
         """Perform ResultCatchment creation steps."""
@@ -139,7 +148,7 @@ class ResultCatchmentCreator(ResultLocationCreator):
         self.set_static_attribute("area")
         self.set_static_attribute("type")
 
-    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
+    def add_to_result_quantity_maps(self, quantity_id: str, result_quantity: ResultQuantity):
         """Add catchment result quantity to result quantity maps."""
         self.add_to_result_quantity_map(quantity_id, result_quantity, self.result_quantity_map)
 

--- a/mikeio1d/result_network/result_catchments.py
+++ b/mikeio1d/result_network/result_catchments.py
@@ -1,13 +1,16 @@
 """ResultCatchments class."""
 
 from __future__ import annotations
-
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Dict
     from typing import Callable
     from geopandas import GeoDataFrame
+
+    from ..res1d import Res1D
+
+    from DHI.Mike1D.ResultDataAccess import Res1DCatchment
 
 from ..dotnet import pythonnet_implementation as impl
 from ..pandas_extension import ResultFrameAggregator
@@ -32,12 +35,11 @@ class ResultCatchments(ResultLocations):
 
     """
 
-    def __init__(self, res1d):
+    def __init__(self, res1d: Res1D):
         ResultLocations.__init__(self)
 
         res1d.network.catchments = self
         self._group = TimeSeriesIdGroup.CATCHMENT
-        self._geometries = None
 
         self._creator = ResultCatchmentsCreator(self, res1d)
         self._creator.create()
@@ -108,7 +110,7 @@ class ResultCatchmentsCreator(ResultLocationsCreator):
 
     """
 
-    def __init__(self, result_locations, res1d):
+    def __init__(self, result_locations: ResultCatchments, res1d: Res1D):
         ResultLocationsCreator.__init__(self, result_locations, res1d)
         self.catchment_label = "c_"
 
@@ -120,7 +122,7 @@ class ResultCatchmentsCreator(ResultLocationsCreator):
     def set_catchments(self):
         """Set attributes to the current ResultCatchments object based on the catchment ID."""
         for catchment in self.data.Catchments:
-            catchment = impl(catchment)
+            catchment: Res1DCatchment = impl(catchment)
             # TODO: Figure out if we should we have res1d.reader dependency here?
             if not self.res1d.reader.is_data_set_included(catchment):
                 continue
@@ -132,6 +134,6 @@ class ResultCatchmentsCreator(ResultLocationsCreator):
             )
             setattr(self.result_locations, result_catchment_attribute_string, result_catchment)
 
-    def set_res1d_catchment_to_dict(self, catchment):
+    def set_res1d_catchment_to_dict(self, result_catchment: ResultCatchment):
         """Create a dict entry from catchment ID to ResultCatchment object."""
-        self.result_locations[catchment.id] = catchment
+        self.result_locations[result_catchment.id] = result_catchment

--- a/mikeio1d/result_network/result_global_data.py
+++ b/mikeio1d/result_network/result_global_data.py
@@ -1,5 +1,16 @@
 """ResultGlobalData class."""
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from ..res1d import Res1D
+    from .result_global_datas import ResultGlobalDatas
+    from .result_quantity import ResultQuantity
+
+    from DHI.Mike1D.ResultDataAccess import IDataItem
+    from DHI.Mike1D.ResultDataAccess import IRes1DGlobalData
+
 from ..query import QueryDataGlobal
 from ..quantities import TimeSeriesIdGroup
 
@@ -24,7 +35,12 @@ class ResultGlobalData(ResultLocation):
 
     """
 
-    def __init__(self, data_item, global_datas, res1d):
+    def __init__(
+        self,
+        data_item: IDataItem,
+        global_datas: ResultGlobalDatas,
+        res1d: Res1D,
+    ):
         ResultLocation.__init__(self)
 
         self._group = TimeSeriesIdGroup.GLOBAL
@@ -32,7 +48,7 @@ class ResultGlobalData(ResultLocation):
         self._creator = ResultGlobalDataCreator(self, data_item, global_datas, res1d)
         self._creator.create()
 
-    def get_m1d_dataset(self, m1d_dataitem=None):
+    def get_m1d_dataset(self, m1d_dataitem: IDataItem = None) -> IRes1DGlobalData:
         """Get IRes1DDataSet object associated with ResultGlobalData.
 
         Parameters
@@ -46,9 +62,9 @@ class ResultGlobalData(ResultLocation):
             IRes1DDataSet object associated with ResultGlobalData.
 
         """
-        return self._creator.res1d.data.GlobalData
+        return self.res1d.data.GlobalData
 
-    def get_query(self, data_item):
+    def get_query(self, data_item: IDataItem) -> QueryDataGlobal:
         """Get a QueryDataGlobal for given data item."""
         quantity_id = data_item.Quantity.Id
         query = QueryDataGlobal(quantity_id)
@@ -71,7 +87,13 @@ class ResultGlobalDataCreator(ResultLocationCreator):
 
     """
 
-    def __init__(self, result_location, data_item, global_datas, res1d):
+    def __init__(
+        self,
+        result_location: ResultGlobalData,
+        data_item: IDataItem,
+        global_datas: ResultGlobalDatas,
+        res1d: Res1D,
+    ):
         ResultLocationCreator.__init__(self, result_location, [data_item], res1d)
         self.global_datas = global_datas
         self.data_item = data_item
@@ -88,6 +110,6 @@ class ResultGlobalDataCreator(ResultLocationCreator):
         """
         self.set_quantity(self.global_datas, self.data_item)
 
-    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
+    def add_to_result_quantity_maps(self, quantity_id: str, result_quantity: ResultQuantity):
         """Add global data result quantity to result quantity maps."""
         self.add_to_network_result_quantity_map(result_quantity)

--- a/mikeio1d/result_network/result_global_data.py
+++ b/mikeio1d/result_network/result_global_data.py
@@ -1,8 +1,10 @@
 """ResultGlobalData class."""
 
 from ..query import QueryDataGlobal
-from .result_location import ResultLocation
 from ..quantities import TimeSeriesIdGroup
+
+from .result_location import ResultLocation
+from .result_location import ResultLocationCreator
 
 
 class ResultGlobalData(ResultLocation):
@@ -23,11 +25,12 @@ class ResultGlobalData(ResultLocation):
     """
 
     def __init__(self, data_item, global_datas, res1d):
-        ResultLocation.__init__(self, [data_item], res1d)
+        ResultLocation.__init__(self)
+
         self._group = TimeSeriesIdGroup.GLOBAL
-        self.data_item = data_item
-        self.global_datas = global_datas
-        self.set_quantities()
+
+        self._creator = ResultGlobalDataCreator(self, data_item, global_datas, res1d)
+        self._creator.create()
 
     def get_m1d_dataset(self, m1d_dataitem=None):
         """Get IRes1DDataSet object associated with ResultGlobalData.
@@ -43,7 +46,39 @@ class ResultGlobalData(ResultLocation):
             IRes1DDataSet object associated with ResultGlobalData.
 
         """
-        return self.res1d.data.GlobalData
+        return self._creator.res1d.data.GlobalData
+
+    def get_query(self, data_item):
+        """Get a QueryDataGlobal for given data item."""
+        quantity_id = data_item.Quantity.Id
+        query = QueryDataGlobal(quantity_id)
+        return query
+
+
+class ResultGlobalDataCreator(ResultLocationCreator):
+    """Helper class for creating ResultGlobalData.
+
+    Parameters
+    ----------
+    result_location:
+        Instance of ResultCatchment, which the ResultCatchmentCreator deals with.
+    data_item : IDataItem
+        MIKE 1D IDataItem object for a global data item.
+    global_datas : ResultGlobalDatas object.
+        A wrapper object for all global data items.
+    res1d : Res1D
+        Res1D object the global data belongs to.
+
+    """
+
+    def __init__(self, result_location, data_item, global_datas, res1d):
+        ResultLocationCreator.__init__(self, result_location, [data_item], res1d)
+        self.global_datas = global_datas
+        self.data_item = data_item
+
+    def create(self):
+        """Perform ResultCatchment creation steps."""
+        self.set_quantities()
 
     def set_quantities(self):
         """Set quantities for ResultGlobalData.
@@ -51,15 +86,8 @@ class ResultGlobalData(ResultLocation):
         Here only a single data item is used for ResultGlobalData.
         Also the quantity attribute is assigned to self.global_data.
         """
-        data_item = self.data_item
-        self.set_quantity(self.global_datas, data_item)
+        self.set_quantity(self.global_datas, self.data_item)
 
     def add_to_result_quantity_maps(self, quantity_id, result_quantity):
         """Add global data result quantity to result quantity maps."""
         self.add_to_network_result_quantity_map(result_quantity)
-
-    def get_query(self, data_item):
-        """Get a QueryDataGlobal for given data item."""
-        quantity_id = data_item.Quantity.Id
-        query = QueryDataGlobal(quantity_id)
-        return query

--- a/mikeio1d/result_network/result_global_datas.py
+++ b/mikeio1d/result_network/result_global_datas.py
@@ -1,5 +1,15 @@
 """ResultGlobalDatas class."""
 
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import List
+
+    from ..res1d import Res1D
+
+    from DHI.Mike1D.ResultDataAccess import IDataItem
+
 from ..dotnet import pythonnet_implementation as impl
 from ..quantities import TimeSeriesIdGroup
 
@@ -22,7 +32,7 @@ class ResultGlobalDatas(ResultLocations):
 
     """
 
-    def __init__(self, res1d):
+    def __init__(self, res1d: Res1D):
         ResultLocations.__init__(self)
         self._group = TimeSeriesIdGroup.GLOBAL
 
@@ -48,9 +58,9 @@ class ResultGlobalDatasCreator(ResultLocationsCreator):
 
     """
 
-    def __init__(self, result_locations, res1d):
+    def __init__(self, result_locations: ResultGlobalDatas, res1d: Res1D):
         ResultLocationsCreator.__init__(self, result_locations, res1d)
-        self.result_global_data_list = []
+        self.result_global_data_list: List[ResultGlobalData] = []
 
     def create(self):
         """Perform ResultCatchments creation steps."""
@@ -63,7 +73,7 @@ class ResultGlobalDatasCreator(ResultLocationsCreator):
             result_global_data = ResultGlobalData(data_item, self.result_locations, self.res1d)
             self.result_global_data_list.append(result_global_data)
 
-    def set_res1d_global_data_to_dict(self, data_item):
+    def set_res1d_global_data_to_dict(self, data_item: IDataItem):
         """Create a dict entry from data item quantity ID to IDatItem object."""
         data_item = impl(data_item)
         self.result_locations[data_item.Quantity.Id] = data_item

--- a/mikeio1d/result_network/result_global_datas.py
+++ b/mikeio1d/result_network/result_global_datas.py
@@ -1,9 +1,11 @@
 """ResultGlobalDatas class."""
 
 from ..dotnet import pythonnet_implementation as impl
-from .result_locations import ResultLocations
-from .result_global_data import ResultGlobalData
 from ..quantities import TimeSeriesIdGroup
+
+from .result_locations import ResultLocations
+from .result_locations import ResultLocationsCreator
+from .result_global_data import ResultGlobalData
 
 
 class ResultGlobalDatas(ResultLocations):
@@ -18,6 +20,26 @@ class ResultGlobalDatas(ResultLocations):
     res1d : Res1D
         Res1D object the catchments belong to.
 
+    """
+
+    def __init__(self, res1d):
+        ResultLocations.__init__(self)
+        self._group = TimeSeriesIdGroup.GLOBAL
+
+        self._creator = ResultGlobalDatasCreator(self, res1d)
+        self._creator.create()
+
+
+class ResultGlobalDatasCreator(ResultLocationsCreator):
+    """A helper class for creating ResultGlobalDatas.
+
+    Parameters
+    ----------
+    result_locations : ResultGlobalDatas
+        Instance of ResultGlobalDatas, which the ResultGlobalDatasCreator deals with.
+    res1d : Res1D
+        Res1D object the global data belong to.
+
     Attributes
     ----------
     result_global_data_list : list of ResultGlobalData objects
@@ -26,20 +48,22 @@ class ResultGlobalDatas(ResultLocations):
 
     """
 
-    def __init__(self, res1d):
-        ResultLocations.__init__(self, res1d)
-        self._group = TimeSeriesIdGroup.GLOBAL
+    def __init__(self, result_locations, res1d):
+        ResultLocationsCreator.__init__(self, result_locations, res1d)
         self.result_global_data_list = []
+
+    def create(self):
+        """Perform ResultCatchments creation steps."""
         self.set_global_data()
 
     def set_global_data(self):
         """Create the ResultGlobalData objects. No attributes are set here."""
         for data_item in self.data.GlobalData.DataItems:
             self.set_res1d_global_data_to_dict(data_item)
-            result_global_data = ResultGlobalData(data_item, self, self.res1d)
+            result_global_data = ResultGlobalData(data_item, self.result_locations, self.res1d)
             self.result_global_data_list.append(result_global_data)
 
     def set_res1d_global_data_to_dict(self, data_item):
         """Create a dict entry from data item quantity ID to IDatItem object."""
         data_item = impl(data_item)
-        self[data_item.Quantity.Id] = data_item
+        self.result_locations[data_item.Quantity.Id] = data_item

--- a/mikeio1d/result_network/result_gridpoint.py
+++ b/mikeio1d/result_network/result_gridpoint.py
@@ -50,33 +50,6 @@ class ResultGridPoint(ResultLocation):
         )
         self._creator.create()
 
-    def get_m1d_dataset(self, m1d_dataitem=None):
-        """Get IRes1DDataSet object associated with ResultGridPoint.
-
-        This is the reach IRes1DDataSet object because grid points do not
-        have a corresponding IRes1DDataSet object.
-
-        Parameters
-        ----------
-        m1d_dataitem: IDataItem, optional
-            Ignored for ResultGridPoint.
-
-        Returns
-        -------
-        IRes1DDataSet
-            IRes1DDataSet object associated with ResultGridPoint.
-
-        """
-        return self.reach
-
-    def get_query(self, data_item):
-        """Get a QueryDataReach for given data item."""
-        quantity_id = data_item.Quantity.Id
-        reach_name = self.reach.Name
-        chainage = self.gridpoint.Chainage
-        query = QueryDataReach(quantity_id, reach_name, chainage)
-        return query
-
     @property
     def result_reach(self) -> ResultReach:
         """Instance of ResultReach that this ResultGridPoint belongs to."""
@@ -119,6 +92,33 @@ class ResultGridPoint(ResultLocation):
     def bottom_level(self):
         """Bottom level of the gridpoint."""
         return self.gridpoint.Z
+
+    def get_m1d_dataset(self, m1d_dataitem=None):
+        """Get IRes1DDataSet object associated with ResultGridPoint.
+
+        This is the reach IRes1DDataSet object because grid points do not
+        have a corresponding IRes1DDataSet object.
+
+        Parameters
+        ----------
+        m1d_dataitem: IDataItem, optional
+            Ignored for ResultGridPoint.
+
+        Returns
+        -------
+        IRes1DDataSet
+            IRes1DDataSet object associated with ResultGridPoint.
+
+        """
+        return self.reach
+
+    def get_query(self, data_item):
+        """Get a QueryDataReach for given data item."""
+        quantity_id = data_item.Quantity.Id
+        reach_name = self.reach.Name
+        chainage = self.gridpoint.Chainage
+        query = QueryDataReach(quantity_id, reach_name, chainage)
+        return query
 
 
 class ResultGridPointCreator(ResultLocationCreator):

--- a/mikeio1d/result_network/result_gridpoint.py
+++ b/mikeio1d/result_network/result_gridpoint.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing import List
+
+    from ..res1d import Res1D
     from .result_reach import ResultReach
+
+    from DHI.Mike1D.ResultDataAccess import IDataItem
+    from DHI.Mike1D.ResultDataAccess import IDataItems
     from DHI.Mike1D.ResultDataAccess import IRes1DReach
     from DHI.Mike1D.ResultDataAccess import IRes1DGridPoint
 
@@ -37,7 +43,15 @@ class ResultGridPoint(ResultLocation):
 
     """
 
-    def __init__(self, reach, gridpoint, data_items, result_reach, res1d, tag=""):
+    def __init__(
+        self,
+        reach: IRes1DReach,
+        gridpoint: IRes1DGridPoint,
+        data_items: IDataItems,
+        result_reach: ResultReach,
+        res1d: Res1D,
+        tag: str = "",
+    ):
         ResultLocation.__init__(self)
 
         self._group = TimeSeriesIdGroup.REACH
@@ -93,7 +107,7 @@ class ResultGridPoint(ResultLocation):
         """Bottom level of the gridpoint."""
         return self.gridpoint.Z
 
-    def get_m1d_dataset(self, m1d_dataitem=None):
+    def get_m1d_dataset(self, m1d_dataitem: IDataItem = None) -> IRes1DGridPoint:
         """Get IRes1DDataSet object associated with ResultGridPoint.
 
         This is the reach IRes1DDataSet object because grid points do not
@@ -112,7 +126,7 @@ class ResultGridPoint(ResultLocation):
         """
         return self.reach
 
-    def get_query(self, data_item):
+    def get_query(self, data_item: IDataItem) -> QueryDataReach:
         """Get a QueryDataReach for given data item."""
         quantity_id = data_item.Quantity.Id
         reach_name = self.reach.Name
@@ -148,8 +162,16 @@ class ResultGridPointCreator(ResultLocationCreator):
 
     """
 
-    def __init__(self, result_location, reach, gridpoint, data_items, result_reach, res1d):
-        empty_data_item_list = []
+    def __init__(
+        self,
+        result_location: ResultGridPoint,
+        reach: IRes1DReach,
+        gridpoint: IRes1DGridPoint,
+        data_items: IDataItems,
+        result_reach: ResultReach,
+        res1d: Res1D,
+    ):
+        empty_data_item_list: List[IDataItem] = []
         ResultLocationCreator.__init__(self, result_location, empty_data_item_list, res1d)
 
         self.reach = reach

--- a/mikeio1d/result_network/result_gridpoint.py
+++ b/mikeio1d/result_network/result_gridpoint.py
@@ -1,8 +1,19 @@
 """ResultGridPoint class."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .result_reach import ResultReach
+    from DHI.Mike1D.ResultDataAccess import IRes1DReach
+    from DHI.Mike1D.ResultDataAccess import IRes1DGridPoint
+
 from ..query import QueryDataReach
 from ..quantities import TimeSeriesIdGroup
+
 from .result_location import ResultLocation
+from .result_location import ResultLocationCreator
 
 
 class ResultGridPoint(ResultLocation):
@@ -17,39 +28,27 @@ class ResultGridPoint(ResultLocation):
     data_items : list of IDataItem objects
         A list of IDataItem objects (vector data object) the
         gridpoint has values defined on.
+    result_reach : ResultReach
+        Instance of ResultReach that this ResultGridPoint belongs to.
     res1d : Res1D
         Res1D object the grid point belongs to.
-
-    Attributes
-    ----------
-    structure_data_items : list of IDataItem object.
-        List of IDataItem objects belonging to a structures
-        defined on the current grid point.
+    tag : str
+        Tag for reach location span where grid point belongs to.
 
     """
 
     def __init__(self, reach, gridpoint, data_items, result_reach, res1d, tag=""):
-        empty_data_item_list = []
-        ResultLocation.__init__(self, empty_data_item_list, res1d)
+        ResultLocation.__init__(self)
+
         self._group = TimeSeriesIdGroup.REACH
         self._name = reach.Name
         self._chainage = gridpoint.Chainage
         self._tag = tag
-        self.reach = reach
-        self.gridpoint = gridpoint
-        self.result_reach = result_reach
-        self.structure_data_items = []
-        self.element_indices = []
 
-        self.set_static_attributes()
-
-    def set_static_attributes(self):
-        """Set static attributes. These show up in the html repr."""
-        self.set_static_attribute("reach_name")
-        self.set_static_attribute("chainage")
-        self.set_static_attribute("xcoord")
-        self.set_static_attribute("ycoord")
-        self.set_static_attribute("bottom_level")
+        self._creator = ResultGridPointCreator(
+            self, reach, gridpoint, data_items, result_reach, res1d
+        )
+        self._creator.create()
 
     def get_m1d_dataset(self, m1d_dataitem=None):
         """Get IRes1DDataSet object associated with ResultGridPoint.
@@ -70,18 +69,6 @@ class ResultGridPoint(ResultLocation):
         """
         return self.reach
 
-    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
-        """Add grid point result quantity to result quantity maps."""
-        self.add_to_result_quantity_map(quantity_id, result_quantity, self.result_quantity_map)
-
-        reach_result_quantity_map = self.result_reach.result_quantity_map
-        self.add_to_result_quantity_map(quantity_id, result_quantity, reach_result_quantity_map)
-
-        reaches_result_quantity_map = self.res1d.network.reaches.result_quantity_map
-        self.add_to_result_quantity_map(quantity_id, result_quantity, reaches_result_quantity_map)
-
-        self.add_to_network_result_quantity_map(result_quantity)
-
     def get_query(self, data_item):
         """Get a QueryDataReach for given data item."""
         quantity_id = data_item.Quantity.Id
@@ -90,14 +77,23 @@ class ResultGridPoint(ResultLocation):
         query = QueryDataReach(quantity_id, reach_name, chainage)
         return query
 
-    def add_data_item(self, data_item, element_index):
-        """Add data item to grid point data items list."""
-        self.data_items.append(data_item)
-        self.element_indices.append(element_index)
+    @property
+    def result_reach(self) -> ResultReach:
+        """Instance of ResultReach that this ResultGridPoint belongs to."""
+        # TODO: Remove or rename to reach in 1.0.0
+        return self._creator.result_reach
 
-    def add_structure_data_item(self, data_item):
-        """Add data item to structure data items list."""
-        self.structure_data_items.append(data_item)
+    @property
+    def reach(self) -> IRes1DReach:
+        """IRes1DReach corresponding to this result location."""
+        # TODO: Consider to remove or rename this property to res1d_reach for version 1.0.0
+        return self._creator.reach
+
+    @property
+    def gridpoint(self) -> IRes1DGridPoint:
+        """IRes1DGridPoint corresponding to this result location."""
+        # TODO: Consider to remove or rename this property to res1d_gridpoint for version 1.0.0
+        return self._creator.gridpoint
 
     @property
     def reach_name(self):
@@ -123,3 +119,74 @@ class ResultGridPoint(ResultLocation):
     def bottom_level(self):
         """Bottom level of the gridpoint."""
         return self.gridpoint.Z
+
+
+class ResultGridPointCreator(ResultLocationCreator):
+    """Helper class for creating ResultGridPoint.
+
+    Parameters
+    ----------
+    result_location : ResultGridPoint
+        Instance of ResultGridPoint, which the ResultGridPointCreator deals with.
+    reach: IRes1DReach
+        MIKE 1D IRes1DReach object.
+    gridpoint IRes1DGridPoint
+        MIKE 1D IRes1DGridPoint object.
+    data_items : list of IDataItem objects
+        A list of IDataItem objects (vector data object) the
+        gridpoint has values defined on.
+    result_reach : ResultReach
+        Instance of ResultReach that this ResultGridPoint belongs to.
+    res1d : Res1D
+        Res1D object the grid point belongs to.
+
+    Attributes
+    ----------
+    structure_data_items : list of IDataItem object.
+        List of IDataItem objects belonging to a structures
+        defined on the current grid point.
+
+    """
+
+    def __init__(self, result_location, reach, gridpoint, data_items, result_reach, res1d):
+        empty_data_item_list = []
+        ResultLocationCreator.__init__(self, result_location, empty_data_item_list, res1d)
+
+        self.reach = reach
+        self.gridpoint = gridpoint
+        self.result_reach = result_reach
+        self.structure_data_items = []
+        self.element_indices = []
+
+    def create(self):
+        """Perform ResultGridPoint creation steps."""
+        self.set_static_attributes()
+
+    def set_static_attributes(self):
+        """Set static attributes. These show up in the html repr."""
+        self.set_static_attribute("reach_name")
+        self.set_static_attribute("chainage")
+        self.set_static_attribute("xcoord")
+        self.set_static_attribute("ycoord")
+        self.set_static_attribute("bottom_level")
+
+    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
+        """Add grid point result quantity to result quantity maps."""
+        self.add_to_result_quantity_map(quantity_id, result_quantity, self.result_quantity_map)
+
+        reach_result_quantity_map = self.result_reach._creator.result_quantity_map
+        self.add_to_result_quantity_map(quantity_id, result_quantity, reach_result_quantity_map)
+
+        reaches_result_quantity_map = self.res1d.network.reaches._creator.result_quantity_map
+        self.add_to_result_quantity_map(quantity_id, result_quantity, reaches_result_quantity_map)
+
+        self.add_to_network_result_quantity_map(result_quantity)
+
+    def add_data_item(self, data_item, element_index):
+        """Add data item to grid point data items list."""
+        self.data_items.append(data_item)
+        self.element_indices.append(element_index)
+
+    def add_structure_data_item(self, data_item):
+        """Add data item to structure data items list."""
+        self.structure_data_items.append(data_item)

--- a/mikeio1d/result_network/result_location.py
+++ b/mikeio1d/result_network/result_location.py
@@ -211,7 +211,7 @@ class ResultLocationCreator(ABC):
         """Set a single quantity attribute on the obj."""
         m1d_dataset = self.result_location.get_m1d_dataset(data_item)
         result_quantity = ResultQuantity(obj, data_item, self.res1d, m1d_dataset, element_index)
-        self.res1d.network.add_result_quantity_to_map(result_quantity)
+        self.res1d.network._add_result_quantity_to_map(result_quantity)
 
         quantity = data_item.Quantity
         quantity_id = quantity.Id
@@ -318,5 +318,5 @@ class ResultLocationCreator(ABC):
 
         """
         network = self.res1d.network
-        tsid = network.add_result_quantity_to_map(result_quantity)
+        tsid = network._add_result_quantity_to_map(result_quantity)
         return tsid

--- a/mikeio1d/result_network/result_location.py
+++ b/mikeio1d/result_network/result_location.py
@@ -15,21 +15,108 @@ if TYPE_CHECKING:  # pragma: no cover
     from ..result_reader_writer.result_reader import ColumnMode
 
 from abc import ABC
-from abc import abstractclassmethod
+from abc import abstractmethod
+
+from ..quantities import TimeSeriesId
+from ..quantities import DerivedQuantity
 
 from .result_quantity import ResultQuantity
 from .result_quantity_derived import ResultQuantityDerived
 from .various import make_proper_variable_name
 from .various import build_html_repr_from_sections
-from ..quantities import TimeSeriesId
-from ..quantities import DerivedQuantity
 
 
 class ResultLocation(ABC):
-    """A base class for a network location (node, reach) or a catchment wrapper class.
+    """A base class for a network location (node, reach) or a catchment wrapper class."""
+
+    def __init__(self):
+        self._group = ""
+        self._name = ""
+        self._tag = ""
+        self._creator: ResultLocationCreator = None
+
+    def __repr__(self) -> str:
+        """Return a string representation of the object."""
+        return f"<{self.__class__.__name__}>"
+
+    def _repr_html_(self) -> str:
+        return self._creator.repr_html()
+
+    def read(self, column_mode: Optional[str | ColumnMode] = None) -> pd.DataFrame:
+        """Read the time series data for all quantities at this location into a DataFrame.
+
+        Parameters
+        ----------
+        column_mode : str | ColumnMode (optional)
+            Specifies the type of column index of returned DataFrame.
+            'all' - column MultiIndex with levels matching TimeSeriesId objects.
+            'compact' - same as 'all', but removes levels with default values.
+            'timeseries' - column index of TimeSeriesId objects
+
+        """
+        qlists = self._creator.result_quantity_map.values()
+        result_quantities = [q for qlist in qlists for q in qlist]
+        timesries_ids = [q.timeseries_id for q in result_quantities]
+        reader = self.res1d.reader
+        df = reader.read(timesries_ids, column_mode=column_mode)
+        return df
+
+    @property
+    def res1d(self) -> Res1D:
+        """The Res1D instance that this location belongs to."""
+        # TODO: Consider to remove this property for version 1.0.0
+        return self._creator.res1d
+
+    @property
+    def group(self) -> List[str]:
+        """The TimeSeriesIdGroup assosciated with this location."""
+        return self._group
+
+    @property
+    def quantities(self) -> List[str]:
+        """A list of available quantities."""
+        return list(self._creator.result_quantity_map.keys())
+
+    @property
+    def derived_quantities(self) -> List[str]:
+        """A list of available derived quantities."""
+        return list(self._creator.result_quantity_derived_map.keys())
+
+    @abstractmethod
+    def get_m1d_dataset(self, m1d_dataitem=None):
+        """Get IRes1DDataSet object associated with ResultLocation.
+
+        Parameters
+        ----------
+        m1d_dataitem: IDataItem
+            Usually ignored, except for ResultReach.
+
+        Returns
+        -------
+        IRes1DDataSet
+            IRes1DDataSet object associated with ResultLocation.
+
+        """
+        ...
+
+    def add_query(self, data_item):
+        """Add a query to ResultNetwork.queries list."""
+        query = self.get_query(data_item)
+        self.res1d.network.add_query(query)
+
+    @abstractmethod
+    def get_query(self, data_item):
+        """Create a query for given data item."""
+        ...
+
+
+class ResultLocationCreator(ABC):
+    """A base helper class for creating ResultLocation.
 
     Parameters
     ----------
+    result_location: ResultLocation
+        Instance of ResultLocation, which the ResultLocationCreator deals with.
     data_items: IDataItems
         MIKE 1D IDataItems object.
     res1d : Res1D
@@ -48,78 +135,53 @@ class ResultLocation(ABC):
     element_indices : list
         List of integers representing element index for entries in data_items.
         For non grid point locations this is typically None.
+    static_attributes : list
+        List of static attributes, that is mainly used when generating HTML representation.
 
     """
 
-    def __init__(self, data_items, res1d: Res1D):
-        self._name = ""
-        self._tag = ""
+    def __init__(self, result_location, data_items, res1d: Res1D):
+        self.result_location = result_location
         self.data_items = data_items
         self.res1d = res1d
+
         self.quantity_label = "q_"
         self.result_quantity_map: Dict[str, List[ResultQuantity]] = {}
         self.result_quantity_derived_map: Dict[str, ResultQuantityDerived] = {}
         self.element_indices = None
-        self._static_attributes = []
+        self.static_attributes = []
 
-    def __repr__(self) -> str:
-        """Return a string representation of the object."""
-        return f"<{self.__class__.__name__}>"
+    @abstractmethod
+    def create(self):
+        """Perform ResultLocation creation steps."""
+        ...
 
-    def _repr_html_(self) -> str:
-        attributes = {k: getattr(self, k) for k in self._static_attributes}
+    def repr_html(self) -> str:
+        """HTML representation."""
+        result_location = self.result_location
+        attributes = {k: getattr(result_location, k) for k in self.static_attributes}
         total_attributes = len(attributes)
-        total_quantities = len(self.quantities)
-        total_derived_quantities = len(self.derived_quantities)
+        total_quantities = len(result_location.quantities)
+        total_derived_quantities = len(result_location.derived_quantities)
         pretty_quantities = [
             ResultQuantity.prettify_quantity(self.result_quantity_map[qid][0])
             for qid in self.result_quantity_map
         ]
-        repr = build_html_repr_from_sections(
-            self.__repr__(),
-            [
-                (f"Attributes ({total_attributes})", attributes),
-                (f"Quantities ({total_quantities})", pretty_quantities),
-                (f"Derived Quantities ({total_derived_quantities})", self.derived_quantities),
-            ],
-        )
+        header = self.result_location.__repr__()
+        sections = [
+            (f"Attributes ({total_attributes})", attributes),
+            (f"Quantities ({total_quantities})", pretty_quantities),
+            (
+                f"Derived Quantities ({total_derived_quantities})",
+                result_location.derived_quantities,
+            ),
+        ]
+        repr = build_html_repr_from_sections(header, sections)
         return repr
-
-    def read(self, column_mode: Optional[str | ColumnMode] = None) -> pd.DataFrame:
-        """Read the time series data for all quantities at this location into a DataFrame.
-
-        Parameters
-        ----------
-        column_mode : str | ColumnMode (optional)
-            Specifies the type of column index of returned DataFrame.
-            'all' - column MultiIndex with levels matching TimeSeriesId objects.
-            'compact' - same as 'all', but removes levels with default values.
-            'timeseries' - column index of TimeSeriesId objects
-
-        """
-        result_quantities = [q for qlist in self.result_quantity_map.values() for q in qlist]
-        timesries_ids = [q.timeseries_id for q in result_quantities]
-        df = self.res1d.reader.read(timesries_ids, column_mode=column_mode)
-        return df
-
-    @property
-    def group(self) -> List[str]:
-        """The TimeSeriesIdGroup assosciated with this location."""
-        return self._group
-
-    @property
-    def quantities(self) -> List[str]:
-        """A list of available quantities."""
-        return list(self.result_quantity_map.keys())
-
-    @property
-    def derived_quantities(self) -> List[str]:
-        """A list of available derived quantities."""
-        return list(self.result_quantity_derived_map.keys())
 
     def set_static_attribute(self, name: str):
         """Add static attribute. This shows up in the html repr."""
-        self._static_attributes.append(name)
+        self.static_attributes.append(name)
 
     def set_quantities(self):
         """Set all quantity attributes."""
@@ -129,11 +191,11 @@ class ResultLocation(ABC):
         for i in range(data_items_count):
             data_item = data_items[i]
             element_index = element_indices[i] if element_indices is not None else 0
-            self.set_quantity(self, data_item, element_index)
+            self.set_quantity(self.result_location, data_item, element_index)
 
     def set_quantity(self, obj, data_item, element_index=0):
         """Set a single quantity attribute on the obj."""
-        m1d_dataset = self.get_m1d_dataset(data_item)
+        m1d_dataset = self.result_location.get_m1d_dataset(data_item)
         result_quantity = ResultQuantity(obj, data_item, self.res1d, m1d_dataset, element_index)
         self.res1d.network.add_result_quantity_to_map(result_quantity)
 
@@ -147,17 +209,18 @@ class ResultLocation(ABC):
 
         self.add_to_result_quantity_maps(quantity_id, result_quantity)
 
-    def _can_add_derived_quantity(self, derived_quantity: DerivedQuantity) -> bool:
+    def can_add_derived_quantity(self, derived_quantity: DerivedQuantity) -> bool:
         """Check if a derived quantity can be added to the result locations."""
-        if self.group not in derived_quantity.groups:
+        result_location = self.result_location
+        if result_location.group not in derived_quantity.groups:
             return False
-        elif derived_quantity.source_quantity not in self.quantities:
+        elif derived_quantity.source_quantity not in result_location.quantities:
             return False
         return True
 
     def add_derived_quantity(self, derived_quantity: DerivedQuantity):
         """Add a derived quantity to the result location."""
-        if self._can_add_derived_quantity(derived_quantity):
+        if self.can_add_derived_quantity(derived_quantity):
             self.set_quantity_derived(derived_quantity)
 
     def remove_derived_quantity(self, derived_quantity: DerivedQuantity | str):
@@ -170,12 +233,14 @@ class ResultLocation(ABC):
         result_quantity_attribute_string = make_proper_variable_name(
             derived_quantity, self.quantity_label
         )
-        if hasattr(self, result_quantity_attribute_string):
-            delattr(self, result_quantity_attribute_string)
+        if hasattr(self.result_location, result_quantity_attribute_string):
+            delattr(self.result_location, result_quantity_attribute_string)
 
     def set_quantity_derived(self, derived_quantity: DerivedQuantity):
         """Set a single derived quantity attribute on the obj."""
-        result_quantity_derived = ResultQuantityDerived(derived_quantity, self, self.res1d)
+        result_quantity_derived = ResultQuantityDerived(
+            derived_quantity, self.result_location, self.res1d
+        )
         quantity_id = result_quantity_derived.name
 
         self.result_quantity_derived_map[result_quantity_derived.name] = result_quantity_derived
@@ -183,26 +248,9 @@ class ResultLocation(ABC):
         result_quantity_attribute_string = make_proper_variable_name(
             quantity_id, self.quantity_label
         )
-        setattr(self, result_quantity_attribute_string, result_quantity_derived)
+        setattr(self.result_location, result_quantity_attribute_string, result_quantity_derived)
 
-    @abstractclassmethod
-    def get_m1d_dataset(self, m1d_dataitem=None):
-        """Get IRes1DDataSet object associated with ResultLocation.
-
-        Parameters
-        ----------
-        m1d_dataitem: IDataItem
-            Usually ignored, except for ResultReach.
-
-        Returns
-        -------
-        IRes1DDataSet
-            IRes1DDataSet object associated with ResultLocation.
-
-        """
-        ...
-
-    @abstractclassmethod
+    @abstractmethod
     def add_to_result_quantity_maps(self, quantity_id: str, result_quantity: ResultQuantity):
         """Add to result quantity maps.
 
@@ -258,13 +306,3 @@ class ResultLocation(ABC):
         network = self.res1d.network
         tsid = network.add_result_quantity_to_map(result_quantity)
         return tsid
-
-    def add_query(self, data_item):
-        """Add a query to ResultNetwork.queries list."""
-        query = self.get_query(data_item)
-        self.res1d.network.add_query(query)
-
-    @abstractclassmethod
-    def get_query(self, data_item):
-        """Create a query for given data item."""
-        ...

--- a/mikeio1d/result_network/result_location.py
+++ b/mikeio1d/result_network/result_location.py
@@ -42,25 +42,6 @@ class ResultLocation(ABC):
     def _repr_html_(self) -> str:
         return self._creator.repr_html()
 
-    def read(self, column_mode: Optional[str | ColumnMode] = None) -> pd.DataFrame:
-        """Read the time series data for all quantities at this location into a DataFrame.
-
-        Parameters
-        ----------
-        column_mode : str | ColumnMode (optional)
-            Specifies the type of column index of returned DataFrame.
-            'all' - column MultiIndex with levels matching TimeSeriesId objects.
-            'compact' - same as 'all', but removes levels with default values.
-            'timeseries' - column index of TimeSeriesId objects
-
-        """
-        qlists = self._creator.result_quantity_map.values()
-        result_quantities = [q for qlist in qlists for q in qlist]
-        timesries_ids = [q.timeseries_id for q in result_quantities]
-        reader = self.res1d.reader
-        df = reader.read(timesries_ids, column_mode=column_mode)
-        return df
-
     @property
     def res1d(self) -> Res1D:
         """The Res1D instance that this location belongs to."""
@@ -99,15 +80,34 @@ class ResultLocation(ABC):
         """
         ...
 
+    @abstractmethod
+    def get_query(self, data_item):
+        """Create a query for given data item."""
+        ...
+
     def add_query(self, data_item):
         """Add a query to ResultNetwork.queries list."""
         query = self.get_query(data_item)
         self.res1d.network.add_query(query)
 
-    @abstractmethod
-    def get_query(self, data_item):
-        """Create a query for given data item."""
-        ...
+    def read(self, column_mode: Optional[str | ColumnMode] = None) -> pd.DataFrame:
+        """Read the time series data for all quantities at this location into a DataFrame.
+
+        Parameters
+        ----------
+        column_mode : str | ColumnMode (optional)
+            Specifies the type of column index of returned DataFrame.
+            'all' - column MultiIndex with levels matching TimeSeriesId objects.
+            'compact' - same as 'all', but removes levels with default values.
+            'timeseries' - column index of TimeSeriesId objects
+
+        """
+        qlists = self._creator.result_quantity_map.values()
+        result_quantities = [q for qlist in qlists for q in qlist]
+        timesries_ids = [q.timeseries_id for q in result_quantities]
+        reader = self.res1d.reader
+        df = reader.read(timesries_ids, column_mode=column_mode)
+        return df
 
 
 class ResultLocationCreator(ABC):

--- a/mikeio1d/result_network/result_locations.py
+++ b/mikeio1d/result_network/result_locations.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from DHI.Mike1D.ResultDataAccess import ResultData
     from DHI.Mike1D.ResultDataAccess import IDataItems
 
+from abc import ABC
+from abc import abstractmethod
 import pandas as pd
 
 from ..dotnet import pythonnet_implementation as impl
@@ -35,7 +37,7 @@ from .various import make_proper_variable_name
 from .various import build_html_repr_from_sections
 
 
-class ResultLocations(Dict[str, ResultLocation]):
+class ResultLocations(ABC, Dict[str, ResultLocation]):
     """A base class for a network locations (nodes, reaches) or a catchments wrapper class."""
 
     def __init__(self):
@@ -120,7 +122,7 @@ class ResultLocations(Dict[str, ResultLocation]):
         return df
 
 
-class ResultLocationsCreator:
+class ResultLocationsCreator(ABC):
     """A base helper class for creating ResultLocations.
 
     Parameters
@@ -156,9 +158,10 @@ class ResultLocationsCreator:
         self.result_quantity_map: Dict[str : List[ResultQuantity]] = {}
         self.result_quantity_derived_map: Dict[str, List[ResultQuantityDerived]] = {}
 
+    @abstractmethod
     def create(self):
         """Perform ResultLocations creation steps."""
-        pass
+        ...
 
     def repr_html_(self) -> str:
         """HTML representation."""

--- a/mikeio1d/result_network/result_locations.py
+++ b/mikeio1d/result_network/result_locations.py
@@ -9,7 +9,6 @@ from typing import Dict
 if TYPE_CHECKING:  # pragma: no cover
     from typing import List
     from typing import Optional
-
     import pandas as pd
 
     from ..res1d import Res1D
@@ -18,6 +17,10 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from .result_location import ResultLocation
     from .result_quantity import ResultQuantity
+    from .result_quantity_derived import ResultQuantityDerived
+
+    from DHI.Mike1D.ResultDataAccess import ResultData
+    from DHI.Mike1D.ResultDataAccess import IDataItems
 
 import pandas as pd
 
@@ -143,15 +146,15 @@ class ResultLocationsCreator:
 
     """
 
-    def __init__(self, result_locations, res1d: Res1D):
+    def __init__(self, result_locations: ResultLocations, res1d: Res1D):
         self.result_locations = result_locations
         self.res1d = res1d
 
         self.quantity_label = "q_"
-        self.data = res1d.data
-        self.data_items = res1d.data.DataItems
+        self.data: ResultData = res1d.data
+        self.data_items: IDataItems = res1d.data.DataItems
         self.result_quantity_map: Dict[str : List[ResultQuantity]] = {}
-        self.result_quantity_derived_map = {}
+        self.result_quantity_derived_map: Dict[str, List[ResultQuantityDerived]] = {}
 
     def create(self):
         """Perform ResultLocations creation steps."""
@@ -173,7 +176,7 @@ class ResultLocationsCreator:
         repr = build_html_repr_from_sections(header, sections)
         return repr
 
-    def set_quantity_collections(self, result_locations=None):
+    def set_quantity_collections(self, result_locations: ResultLocations = None):
         """Set all quantity collection attributes."""
         result_locations = self.result_locations if result_locations is None else result_locations
 
@@ -246,7 +249,7 @@ class ResultLocationsCreator:
         )
         setattr(self.result_locations, result_quantity_attribute_string, result_quantity_derived)
 
-    def set_res1d_object_to_dict(self, dict_key, obj):
+    def set_res1d_object_to_dict(self, dict_key: str, obj):
         """Create a dict entry from a key name to an object or a list of objects."""
         obj = impl(obj)
         result_locations = self.result_locations

--- a/mikeio1d/result_network/result_network.py
+++ b/mikeio1d/result_network/result_network.py
@@ -87,9 +87,9 @@ class ResultNetwork:
         self.result_quantity_map: Dict[TimeSeriesId, ResultQuantity] = {}
 
         self.res1d.network = self
-        self.set_result_locations()
+        self._set_result_locations()
 
-    def add_result_quantity_to_map(self, result_quantity: ResultQuantity) -> TimeSeriesId:
+    def _add_result_quantity_to_map(self, result_quantity: ResultQuantity) -> TimeSeriesId:
         """Add a ResultQuantity to map of all possible ResultQuantities.
 
         Parameters
@@ -113,7 +113,7 @@ class ResultNetwork:
 
         return tsid
 
-    def set_result_locations(self):
+    def _set_result_locations(self):
         """Assign nodes, reaches, catchments, global_data properties."""
         res1d = self.res1d
         self.nodes = ResultNodes(res1d)

--- a/mikeio1d/result_network/result_network.py
+++ b/mikeio1d/result_network/result_network.py
@@ -9,6 +9,11 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Dict
     from geopandas import GeoDataFrame
 
+    from ..res1d import Res1D
+
+    from DHI.Mike1D.ResultDataAccess import ResultData
+    from DHI.Mike1D.ResultDataAccess import IDataItem
+
 import pandas as pd
 
 from ..various import try_import_geopandas
@@ -72,10 +77,10 @@ class ResultNetwork:
 
     """
 
-    def __init__(self, res1d):
+    def __init__(self, res1d: Res1D):
         self.res1d = res1d
-        self.data = res1d.data
-        self.data_items = res1d.data.DataItems
+        self.data: ResultData = res1d.data
+        self.data_items: List[IDataItem] = res1d.data.DataItems
 
         self.queue: List[TimeSeriesId] = []
 

--- a/mikeio1d/result_network/result_network.py
+++ b/mikeio1d/result_network/result_network.py
@@ -131,10 +131,10 @@ class ResultNetwork:
             Derived quantity to be added to the result network.
 
         """
-        self.nodes.add_derived_quantity(derived_quantity)
-        self.reaches.add_derived_quantity(derived_quantity)
-        self.catchments.add_derived_quantity(derived_quantity)
-        self.structures.add_derived_quantity(derived_quantity)
+        self.nodes._creator.add_derived_quantity(derived_quantity)
+        self.reaches._creator.add_derived_quantity(derived_quantity)
+        self.catchments._creator.add_derived_quantity(derived_quantity)
+        self.structures._creator.add_derived_quantity(derived_quantity)
 
     def remove_derived_quantity(self, derived_quantity: ResultQuantity | str):
         """Remove a derived quantity from the result network.
@@ -145,10 +145,10 @@ class ResultNetwork:
             Derived quantity to be removed from the result network. Either a ResultQuantity object or its name.
 
         """
-        self.nodes.remove_derived_quantity(derived_quantity)
-        self.reaches.remove_derived_quantity(derived_quantity)
-        self.catchments.remove_derived_quantity(derived_quantity)
-        self.structures.remove_derived_quantity(derived_quantity)
+        self.nodes._creator.remove_derived_quantity(derived_quantity)
+        self.reaches._creator.remove_derived_quantity(derived_quantity)
+        self.catchments._creator.remove_derived_quantity(derived_quantity)
+        self.structures._creator.remove_derived_quantity(derived_quantity)
 
     def to_geopandas(self) -> GeoDataFrame:
         """Convert ResultNetwork to a GeoDataFrame. Require geopandas to be installed."""

--- a/mikeio1d/result_network/result_node.py
+++ b/mikeio1d/result_network/result_node.py
@@ -6,13 +6,16 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from ..geometry import NodePoint
+    from DHI.Mike1D.ResultDataAccess import IRes1DNode
 
 from warnings import warn
 
 from ..query import QueryDataNode
-from .result_location import ResultLocation
 from ..various import try_import_shapely
 from ..quantities import TimeSeriesIdGroup
+
+from .result_location import ResultLocation
+from .result_location import ResultLocationCreator
 
 
 class ResultNode(ResultLocation):
@@ -20,18 +23,21 @@ class ResultNode(ResultLocation):
 
     Parameters
     ----------
+    node : IRes1DNode
+        MIKE 1D IRes1DNode object.
     res1d : Res1D
         Res1D object the node belongs to.
 
     """
 
     def __init__(self, node, res1d):
-        ResultLocation.__init__(self, node.DataItems, res1d)
+        ResultLocation.__init__(self)
+
         self._group = TimeSeriesIdGroup.NODE
         self._name = node.ID
-        self._node = node
-        self.set_quantities()
-        self.set_static_attributes()
+
+        self._creator = ResultNodeCreator(self, node, res1d)
+        self._creator.create()
 
     def __repr__(self) -> str:
         """Return a string representation of the object."""
@@ -42,12 +48,12 @@ class ResultNode(ResultLocation):
         # TODO: Remove this in 1.0.0
         if name == "node":
             warn("Accessing IRes1DNode attribute via .node is deprecated. Use ._node.")
-            return self._node
-        elif hasattr(self._node, name):
+            return self.node
+        elif hasattr(self.node, name):
             warn(
                 f"Accessing IRes1DNode attribute {name} directly is deprecated. Use static attributes instead, or ._node.{name}."
             )
-            return getattr(self._node, name)
+            return getattr(self.node, name)
         else:
             object.__getattribute__(self, name)
 
@@ -65,7 +71,125 @@ class ResultNode(ResultLocation):
             IRes1DDataSet object associated with ResultNode.
 
         """
-        return self._node
+        return self.node
+
+    def get_query(self, data_item):
+        """Get a QueryDataNode for given data item."""
+        quantity_id = data_item.Quantity.Id
+        node_id = self.node.ID
+        query = QueryDataNode(quantity_id, node_id)
+        return query
+
+    @property
+    def node(self) -> IRes1DNode:
+        """IRes1DNode corresponding to this result location."""
+        # TODO: Consider to remove or rename this property to res1d_node for version 1.0.0
+        return self._creator.node
+
+    @property
+    def geometry(self) -> NodePoint:
+        """A geometric representation of the node. Requires shapely."""
+        try_import_shapely()
+        from ..geometry import NodePoint
+
+        return NodePoint.from_res1d_node(self.node)
+
+    @property
+    def id(self) -> str:
+        """Node ID."""
+        return self.node.ID
+
+    @property
+    def type(self) -> str:
+        """Node type."""
+        node_type = self.node.GetType().Name[5:]  # Removes 'Res1D' from type name
+        return node_type
+
+    @property
+    def xcoord(self) -> float:
+        """X coordinate of the node."""
+        return self.node.XCoordinate
+
+    @property
+    def ycoord(self) -> float:
+        """Y coordinate of the node."""
+        return self.node.YCoordinate
+
+    @property
+    def ground_level(self) -> float | None:
+        """Ground level of the node.
+
+        Returns
+        -------
+            float: Ground level of the node.
+            None: If the node does not have a ground level.
+        """
+        if hasattr(self.node, "GroundLevel"):
+            return self.node.GroundLevel
+        return None
+
+    @property
+    def bottom_level(self) -> float | None:
+        """Bottom level of the node.
+
+        Returns
+        -------
+            float: Bottom level of the node.
+            None: If the node does not have a bottom level.
+        """
+        if hasattr(self.node, "BottomLevel"):
+            return self.node.BottomLevel
+        return None
+
+    @property
+    def critical_level(self) -> float | None:
+        """Critical level of the node.
+
+        Returns
+        -------
+            float: Critical level of the node.
+            None: If the node does not have a critical level.
+        """
+        if hasattr(self.node, "CriticalLevel"):
+            return self.node.CriticalLevel
+        return None
+
+    @property
+    def diameter(self) -> float | None:
+        """Diameter of the node.
+
+        Returns
+        -------
+            float: Diameter of the node.
+            None: If the node does not have a diameter.
+        """
+        if hasattr(self.node, "Diameter"):
+            return self.node.Diameter
+        return None
+
+
+class ResultNodeCreator(ResultLocationCreator):
+    """Helper class for creating ResultNode.
+
+    Parameters
+    ----------
+    result_location : ResultNode
+        Instance of ResultNode, which the ResultNodeCreator deals with.
+    node : IRes1DNode
+        MIKE 1D IRes1DNode object.
+    res1d : Res1D
+        Res1D object the node belongs to.
+
+    """
+
+    def __init__(self, result_location, node, res1d):
+        ResultLocationCreator.__init__(self, result_location, node.DataItems, res1d)
+        self.node = node
+
+    def create(self):
+        """Perform ResultNode creation steps."""
+        self.set_quantities()
+        self.set_static_attributes()
 
     def set_static_attributes(self):
         """Set static attributes. These show up in the html repr."""
@@ -82,95 +206,7 @@ class ResultNode(ResultLocation):
         """Add node result quantity to result quantity maps."""
         self.add_to_result_quantity_map(quantity_id, result_quantity, self.result_quantity_map)
 
-        nodes_result_quantity_map = self.res1d.network.nodes.result_quantity_map
+        nodes_result_quantity_map = self.res1d.network.nodes._creator.result_quantity_map
         self.add_to_result_quantity_map(quantity_id, result_quantity, nodes_result_quantity_map)
 
         self.add_to_network_result_quantity_map(result_quantity)
-
-    def get_query(self, data_item):
-        """Get a QueryDataNode for given data item."""
-        quantity_id = data_item.Quantity.Id
-        node_id = self._node.ID
-        query = QueryDataNode(quantity_id, node_id)
-        return query
-
-    @property
-    def geometry(self) -> NodePoint:
-        """A geometric representation of the node. Requires shapely."""
-        try_import_shapely()
-        from ..geometry import NodePoint
-
-        return NodePoint.from_res1d_node(self._node)
-
-    @property
-    def id(self) -> str:
-        """Node ID."""
-        return self._node.ID
-
-    @property
-    def type(self) -> str:
-        """Node type."""
-        node_type = self._node.GetType().Name[5:]  # Removes 'Res1D' from type name
-        return node_type
-
-    @property
-    def xcoord(self) -> float:
-        """X coordinate of the node."""
-        return self._node.XCoordinate
-
-    @property
-    def ycoord(self) -> float:
-        """Y coordinate of the node."""
-        return self._node.YCoordinate
-
-    @property
-    def ground_level(self) -> float | None:
-        """Ground level of the node.
-
-        Returns
-        -------
-            float: Ground level of the node.
-            None: If the node does not have a ground level.
-        """
-        if hasattr(self._node, "GroundLevel"):
-            return self._node.GroundLevel
-        return None
-
-    @property
-    def bottom_level(self) -> float | None:
-        """Bottom level of the node.
-
-        Returns
-        -------
-            float: Bottom level of the node.
-            None: If the node does not have a bottom level.
-        """
-        if hasattr(self._node, "BottomLevel"):
-            return self._node.BottomLevel
-        return None
-
-    @property
-    def critical_level(self) -> float | None:
-        """Critical level of the node.
-
-        Returns
-        -------
-            float: Critical level of the node.
-            None: If the node does not have a critical level.
-        """
-        if hasattr(self._node, "CriticalLevel"):
-            return self._node.CriticalLevel
-        return None
-
-    @property
-    def diameter(self) -> float | None:
-        """Diameter of the node.
-
-        Returns
-        -------
-            float: Diameter of the node.
-            None: If the node does not have a diameter.
-        """
-        if hasattr(self._node, "Diameter"):
-            return self._node.Diameter
-        return None

--- a/mikeio1d/result_network/result_node.py
+++ b/mikeio1d/result_network/result_node.py
@@ -57,29 +57,6 @@ class ResultNode(ResultLocation):
         else:
             object.__getattribute__(self, name)
 
-    def get_m1d_dataset(self, m1d_dataitem=None):
-        """Get IRes1DDataSet object associated with ResultNode.
-
-        Parameters
-        ----------
-        m1d_dataitem: IDataItem, optional
-            Ignored for ResultNode.
-
-        Returns
-        -------
-        IRes1DDataSet
-            IRes1DDataSet object associated with ResultNode.
-
-        """
-        return self.node
-
-    def get_query(self, data_item):
-        """Get a QueryDataNode for given data item."""
-        quantity_id = data_item.Quantity.Id
-        node_id = self.node.ID
-        query = QueryDataNode(quantity_id, node_id)
-        return query
-
     @property
     def node(self) -> IRes1DNode:
         """IRes1DNode corresponding to this result location."""
@@ -166,6 +143,29 @@ class ResultNode(ResultLocation):
         if hasattr(self.node, "Diameter"):
             return self.node.Diameter
         return None
+
+    def get_m1d_dataset(self, m1d_dataitem=None):
+        """Get IRes1DDataSet object associated with ResultNode.
+
+        Parameters
+        ----------
+        m1d_dataitem: IDataItem, optional
+            Ignored for ResultNode.
+
+        Returns
+        -------
+        IRes1DDataSet
+            IRes1DDataSet object associated with ResultNode.
+
+        """
+        return self.node
+
+    def get_query(self, data_item):
+        """Get a QueryDataNode for given data item."""
+        quantity_id = data_item.Quantity.Id
+        node_id = self.node.ID
+        query = QueryDataNode(quantity_id, node_id)
+        return query
 
 
 class ResultNodeCreator(ResultLocationCreator):

--- a/mikeio1d/result_network/result_node.py
+++ b/mikeio1d/result_network/result_node.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
+    from ..res1d import Res1D
     from ..geometry import NodePoint
+    from .result_quantity import ResultQuantity
+
+    from DHI.Mike1D.ResultDataAccess import IDataItem
     from DHI.Mike1D.ResultDataAccess import IRes1DNode
 
 from warnings import warn
@@ -144,7 +148,7 @@ class ResultNode(ResultLocation):
             return self.node.Diameter
         return None
 
-    def get_m1d_dataset(self, m1d_dataitem=None):
+    def get_m1d_dataset(self, m1d_dataitem: IDataItem = None) -> IRes1DNode:
         """Get IRes1DDataSet object associated with ResultNode.
 
         Parameters
@@ -160,7 +164,7 @@ class ResultNode(ResultLocation):
         """
         return self.node
 
-    def get_query(self, data_item):
+    def get_query(self, data_item: IDataItem) -> QueryDataNode:
         """Get a QueryDataNode for given data item."""
         quantity_id = data_item.Quantity.Id
         node_id = self.node.ID
@@ -182,7 +186,12 @@ class ResultNodeCreator(ResultLocationCreator):
 
     """
 
-    def __init__(self, result_location, node, res1d):
+    def __init__(
+        self,
+        result_location: ResultNode,
+        node: IRes1DNode,
+        res1d: Res1D,
+    ):
         ResultLocationCreator.__init__(self, result_location, node.DataItems, res1d)
         self.node = node
 
@@ -202,7 +211,7 @@ class ResultNodeCreator(ResultLocationCreator):
         self.set_static_attribute("critical_level")
         self.set_static_attribute("diameter")
 
-    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
+    def add_to_result_quantity_maps(self, quantity_id: str, result_quantity: ResultQuantity):
         """Add node result quantity to result quantity maps."""
         self.add_to_result_quantity_map(quantity_id, result_quantity, self.result_quantity_map)
 

--- a/mikeio1d/result_network/result_nodes.py
+++ b/mikeio1d/result_network/result_nodes.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable
     from geopandas import GeoDataFrame
 
+    from ..res1d import Res1D
+
 from ..dotnet import pythonnet_implementation as impl
 from ..pandas_extension import ResultFrameAggregator
 from ..quantities import TimeSeriesIdGroup
@@ -32,7 +34,7 @@ class ResultNodes(ResultLocations):
 
     """
 
-    def __init__(self, res1d):
+    def __init__(self, res1d: Res1D):
         ResultLocations.__init__(self)
 
         res1d.network.nodes = self
@@ -119,7 +121,7 @@ class ResultNodesCreator(ResultLocationsCreator):
 
     """
 
-    def __init__(self, result_locations, res1d):
+    def __init__(self, result_locations: ResultNodes, res1d: Res1D):
         ResultLocationsCreator.__init__(self, result_locations, res1d)
         self.node_label = "n_"
 
@@ -141,6 +143,6 @@ class ResultNodesCreator(ResultLocationsCreator):
             result_node_attribute_string = make_proper_variable_name(node.ID, self.node_label)
             setattr(self.result_locations, result_node_attribute_string, result_node)
 
-    def set_res1d_node_to_dict(self, result_node):
+    def set_res1d_node_to_dict(self, result_node: ResultNode):
         """Create a dict entry from node ID to ResultNode object."""
         self.result_locations[result_node.id] = result_node

--- a/mikeio1d/result_network/result_reach.py
+++ b/mikeio1d/result_network/result_reach.py
@@ -8,16 +8,19 @@ from typing import Dict
 if TYPE_CHECKING:  # pragma: no cover
     from ..geometry import ReachGeometry
     from typing import List
+    from DHI.Mike1D.ResultDataAccess import IRes1DReach
 
 import numpy as np
 
-from .result_location import ResultLocation
-from .result_gridpoint import ResultGridPoint
-from .various import make_proper_variable_name
 from ..various import try_import_shapely
 from ..quantities import TimeSeriesId
 from ..quantities import TimeSeriesIdGroup
 from ..dotnet import pythonnet_implementation as impl
+
+from .result_location import ResultLocation
+from .result_location import ResultLocationCreator
+from .result_gridpoint import ResultGridPoint
+from .various import make_proper_variable_name
 
 from DHI.Mike1D.ResultDataAccess import Res1DGridPoint
 from DHI.Mike1D.ResultDataAccess import Res1DCircularCrossSection
@@ -37,37 +40,15 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
     res1d : Res1D
         Res1D object the reach belongs to.
 
-    Attributes
-    ----------
-    chainage_label : str
-        A label, which is appended to all chainage attributes
-        The value used is chainage_label = 'm_'
-    data_items : list of IDataItems objects.
-        A list of MIKE 1D IDataItems objects corresponding to a given reach name.
-    result_gridpoints : list of lists of ResultGridPoint objects.
-        A list containing lists of ResultGridPoint objects.
-        Every list of ResultGridPoint objects correspond to a unique IRes1DReach.
-    current_reach_result_gridpoints : list of ResultGridPoint objects.
-        List of ResultGridPoint objects of currently processed IRes1DReach object.
-        It is updated in set_gridpoints method.
-
     """
 
     def __init__(self, reaches, res1d):
-        data_items = []
-        ResultLocation.__init__(self, data_items, res1d)
+        ResultLocation.__init__(self)
+
         self._group = TimeSeriesIdGroup.REACH
 
-        self.chainage_label = "m_"
-
-        self.result_gridpoints = []
-        self.current_reach_result_gridpoints = None
-
-        self.reaches = []
-        for reach in reaches:
-            self.add_res1d_reach(reach)
-
-        self.set_static_attributes()
+        self._creator = ResultReachCreator(self, reaches, res1d)
+        self._creator.create()
 
     def __repr__(self) -> str:
         """Return a string representation of ResultReach."""
@@ -90,6 +71,311 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
             return self.gridpoints[key]
         return super().__getitem__(key)
 
+    @property
+    def reaches(self) -> List[IRes1DReach]:
+        """List of IRes1DReach corresponding to this result location."""
+        # TODO: Consider to remove or rename this property to res1d_reaches for version 1.0.0
+        return self._creator.reaches
+
+    @property
+    def chainages(self) -> List[str]:
+        """List of chainages for the reach."""
+        return list(self.keys())
+
+    @property
+    def gridpoints(self) -> List[ResultGridPoint]:
+        """List of gridpoints for the reach."""
+        return list(self.values())
+
+    def get_m1d_dataset(self, m1d_dataitem=None):
+        """Get IRes1DDataSet object associated with ResultReach.
+
+        A ResultReach may consist of several IRes1DDataSet objects. Therefore,
+        a IRes1DDataItem must be provided to identify the correct IRes1DDataSet.
+
+        Parameters
+        ----------
+        m1d_dataitem: IDataItem
+            The IRes1DDataItem associated with the returned IRes1DDataSet.
+
+        Returns
+        -------
+        IRes1DDataSet
+            IRes1DDataSet object associated with ResultReach.
+
+        """
+        if m1d_dataitem is None:
+            raise ValueError("m1d_dataitem must be provided for ResultReach.")
+
+        for m1d_reach in self.reaches:
+            if m1d_reach.DataItems.Contains(m1d_dataitem):
+                return m1d_reach
+        raise Exception(
+            "No IRes1DDataSet found on reach for specified IRes1DDataItem: ",
+            m1d_dataitem,
+        )
+
+    def get_query(self, data_item):
+        """Get a query for a data item."""
+        raise NotImplementedError("get_query not implemented for ResultReach. Use ResultGridPoint.")
+
+    @property
+    def geometry(self) -> ReachGeometry:
+        """A geometric representation of the reach. Requires shapely."""
+        try_import_shapely()
+        from ..geometry import ReachGeometry
+
+        return ReachGeometry.from_m1d_reaches(self.reaches)
+
+    @property
+    def name(self) -> str:
+        """Name of the reach."""
+        return self.reaches[0].Name
+
+    @property
+    def length(self) -> float | None:
+        """Length of the reach."""
+        return self._creator._get_total_length()
+
+    @property
+    def start_chainage(self) -> float:
+        """Start chainage of the reach."""
+        return self.reaches[0].LocationSpan.StartChainage
+
+    @property
+    def end_chainage(self) -> float:
+        """End chainage of the reach."""
+        return self.reaches[-1].LocationSpan.EndChainage
+
+    @property
+    def n_gridpoints(self) -> int:
+        """Number of gridpoints in the reach."""
+        return self._creator._get_total_gridpoints()
+
+    @property
+    def start_node(self) -> str | None:
+        """Start node of the reach."""
+        # For resx files, the start and end node indices are not available
+        if self.res1d.file_path.endswith(".resx"):
+            return None
+        return self._creator._get_start_node()
+
+    @property
+    def end_node(self) -> str:
+        """End node of the reach."""
+        # For resx files, the start and end node indices are not available
+        if self.res1d.file_path.endswith(".resx"):
+            return None
+        return self._creator._get_end_node()
+
+    @property
+    def height(self) -> float:
+        """Height of the reach."""
+        return self._creator._get_height()
+
+    @property
+    def full_flow_discharge(self) -> float:
+        """Full flow discharge of the reach."""
+        return self._creator._get_full_flow_discharge()
+
+    def interpolate_reach_ground_level(self, chainage: float) -> float:
+        """Interpolate the ground level at a given chainage by linear interpolation from the bounding node ground levels.
+
+        Parameters
+        ----------
+        chainage: float
+            Chainage for which to interpolate the ground level.
+
+        Returns
+        -------
+        float
+            Interpolated ground level.
+
+        """
+        return self._creator._interpolate_reach_ground_level(chainage)
+
+    def interpolate_reach_critical_level(self, chainage: float) -> float:
+        """Interpolate the critical level at a given chainage by linear interpolation from the bounding node critical levels.
+
+        Parameters
+        ----------
+        chainage: float
+            Chainage for which to interpolate the critical level.
+
+        Returns
+        -------
+        float
+            Interpolated critical level.
+
+        """
+        return self._creator._interpolate_reach_critical_level(chainage)
+
+
+class ResultReachCreator(ResultLocationCreator):
+    """Helper class for creating ResultReach.
+
+    Parameters
+    ----------
+    result_location : ResultReach
+        Instance of ResultReach, which the ResultReachCreator deals with.
+    reaches: list of IRes1DReach
+        A list of MIKE 1D IRes1DReach objects having the same reach name.
+    res1d : Res1D
+        Res1D object the reach belongs to.
+
+    Attributes
+    ----------
+    chainage_label : str
+        A label, which is appended to all chainage attributes
+        The value used is chainage_label = 'm_'
+    data_items : list of IDataItems objects.
+        A list of MIKE 1D IDataItems objects corresponding to a given reach name.
+    result_gridpoints : list of lists of ResultGridPoint objects.
+        A list containing lists of ResultGridPoint objects.
+        Every list of ResultGridPoint objects correspond to a unique IRes1DReach.
+    current_reach_result_gridpoints : list of ResultGridPoint objects.
+        List of ResultGridPoint objects of currently processed IRes1DReach object.
+        It is updated in set_gridpoints method.
+
+    """
+
+    def __init__(self, result_location, reaches, res1d):
+        data_items = []
+        ResultLocationCreator.__init__(self, result_location, data_items, res1d)
+
+        self.reaches_initial = reaches
+
+        self.chainage_label = "m_"
+        self.reaches = []
+        self.result_gridpoints = []
+        self.current_reach_result_gridpoints = None
+
+    def create(self):
+        """Perform ResultReach creation steps."""
+        for reach in self.reaches_initial:
+            self.add_res1d_reach(reach)
+
+        self.set_static_attributes()
+
+    def set_static_attributes(self):
+        """Set static attributes. These show up in the html repr."""
+        self.set_static_attribute("name")
+        self.set_static_attribute("length")
+        self.set_static_attribute("start_chainage")
+        self.set_static_attribute("end_chainage")
+        self.set_static_attribute("n_gridpoints")
+        self.set_static_attribute("start_node")
+        self.set_static_attribute("end_node")
+        self.set_static_attribute("height")
+        self.set_static_attribute("full_flow_discharge")
+
+    def add_res1d_reach(self, reach):
+        """Add a IRes1DReach to ResultReach.
+
+        Parameters
+        ----------
+        reach: IRes1DReach
+            A MIKE 1D IRes1DReach object.
+
+        """
+        self.reaches.append(reach)
+        self.data_items.append(reach.DataItems)
+        self.set_gridpoints(reach)
+        self.set_gridpoint_data_items(reach)
+        for result_gridpoint in self.current_reach_result_gridpoints:
+            result_gridpoint._creator.set_quantities()
+        self.dataset = self.reaches
+
+    def set_gridpoints(self, reach):
+        """Assign chainage attributes to a current ResultReach object from a data provided by IRes1DReach.
+
+        Parameters
+        ----------
+        reach: IRes1DReach
+            A MIKE 1D IRes1DReach object.
+
+        """
+        current_reach_result_gridpoints = []
+        self.current_reach_result_gridpoints = current_reach_result_gridpoints
+        self.result_gridpoints.append(current_reach_result_gridpoints)
+
+        # For SWMM and EPANET results no grid points are defined
+        # so introduce a single one.
+        gridpoint_count = reach.GridPoints.Count
+        if gridpoint_count == 0:
+            gridpoint = Res1DGridPoint()
+            self.set_gridpoint(reach, gridpoint)
+
+        gridpoints = list(reach.GridPoints)
+        tag = self.create_reach_span_tag(gridpoints)
+        for i in range(gridpoint_count):
+            gridpoint = gridpoints[i]
+            self.set_gridpoint(reach, gridpoint, tag)
+
+    def create_reach_span_tag(self, gridpoints):
+        """Create reach span tag to be set on ResultGridPoint."""
+        if len(gridpoints) == 0:
+            return ""
+
+        start_gp = gridpoints[0]
+        end_gp = gridpoints[-1]
+        tag = TimeSeriesId.create_reach_span_tag_from_gridpoints(start_gp, end_gp)
+        return tag
+
+    def set_gridpoint(self, reach, gridpoint, tag=""):
+        """Assign chainage attribute to a current ResultReach object from a data provided by IRes1DReach and IRes1DGridPoint.
+
+        Parameters
+        ----------
+        reach: IRes1DReach
+            A MIKE 1D IRes1DReach object.
+        gridpoint: IRes1DGridPoint
+            A MIKE 1D IRes1DGridPoint object.
+
+        """
+        current_reach_result_gridpoints = self.current_reach_result_gridpoints
+
+        result_gridpoint = ResultGridPoint(
+            reach, gridpoint, reach.DataItems, self.result_location, self.res1d, tag
+        )
+        current_reach_result_gridpoints.append(result_gridpoint)
+
+        chainage_string = f"{gridpoint.Chainage:g}"
+        result_gridpoint_attribute_string = make_proper_variable_name(
+            chainage_string, self.chainage_label
+        )
+        setattr(self.result_location, result_gridpoint_attribute_string, result_gridpoint)
+
+        chainage_str = f"{gridpoint.Chainage:.3f}"
+        self.result_location[chainage_str] = result_gridpoint
+
+    def set_gridpoint_data_items(self, reach):
+        """Assign data items to ResultGridPoint object belonging to current ResultReach from IRes1DReach data items.
+
+        Parameters
+        ----------
+        reach: IRes1DReach
+            A MIKE 1D IRes1DReach object.
+
+        """
+        for data_item in reach.DataItems:
+            # For SWMM and EPANET results IndexList is None.
+            index_list = [0] if data_item.IndexList is None else list(data_item.IndexList)
+            element_count = len(index_list)
+            for element_index in range(element_count):
+                gridpoint_index = index_list[element_index]
+                result_gridpoint = self.current_reach_result_gridpoints[gridpoint_index]
+                if data_item.ItemId is None:
+                    result_gridpoint._creator.add_data_item(data_item, element_index)
+                else:
+                    result_gridpoint._creator.add_structure_data_item(data_item)
+
+    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
+        """Add a quantity to the result quantity maps."""
+        raise NotImplementedError(
+            "add_to_result_quantity_maps not implemented for ResultReachCreatpr. Use ResultGridPointCreator."
+        )
+
     def _get_total_length(self):
         total_length = 0
         for reach in self.reaches:
@@ -102,7 +388,7 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
         return sum([len(gp_list) for gp_list in self.result_gridpoints])
 
     def _get_height(self) -> float:
-        first_gridpoint = impl(self.gridpoints[0].gridpoint)
+        first_gridpoint = impl(self.result_location.gridpoints[0].gridpoint)
 
         if hasattr(first_gridpoint, "CrossSection"):
             cs = impl(first_gridpoint.CrossSection)
@@ -158,238 +444,7 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
 
         return ffd_reach_data.GlobalValue
 
-    @property
-    def chainages(self) -> List[str]:
-        """List of chainages for the reach."""
-        return list(self.keys())
-
-    @property
-    def gridpoints(self) -> List[ResultGridPoint]:
-        """List of gridpoints for the reach."""
-        return list(self.values())
-
-    def set_static_attributes(self):
-        """Set static attributes. These show up in the html repr."""
-        self.set_static_attribute("name")
-        self.set_static_attribute("length")
-        self.set_static_attribute("start_chainage")
-        self.set_static_attribute("end_chainage")
-        self.set_static_attribute("n_gridpoints")
-        self.set_static_attribute("start_node")
-        self.set_static_attribute("end_node")
-        self.set_static_attribute("height")
-        self.set_static_attribute("full_flow_discharge")
-
-    def add_res1d_reach(self, reach):
-        """Add a IRes1DReach to ResultReach.
-
-        Parameters
-        ----------
-        reach: IRes1DReach
-            A MIKE 1D IRes1DReach object.
-
-        """
-        self.reaches.append(reach)
-        self.data_items.append(reach.DataItems)
-        self.set_gridpoints(reach)
-        self.set_gridpoint_data_items(reach)
-        for result_gridpoint in self.current_reach_result_gridpoints:
-            result_gridpoint.set_quantities()
-        self.dataset = self.reaches
-
-    def get_m1d_dataset(self, m1d_dataitem=None):
-        """Get IRes1DDataSet object associated with ResultReach.
-
-        A ResultReach may consist of several IRes1DDataSet objects. Therefore,
-        a IRes1DDataItem must be provided to identify the correct IRes1DDataSet.
-
-        Parameters
-        ----------
-        m1d_dataitem: IDataItem
-            The IRes1DDataItem associated with the returned IRes1DDataSet.
-
-        Returns
-        -------
-        IRes1DDataSet
-            IRes1DDataSet object associated with ResultReach.
-
-        """
-        if m1d_dataitem is None:
-            raise ValueError("m1d_dataitem must be provided for ResultReach.")
-
-        for m1d_reach in self.reaches:
-            if m1d_reach.DataItems.Contains(m1d_dataitem):
-                return m1d_reach
-        raise Exception(
-            "No IRes1DDataSet found on reach for specified IRes1DDataItem: ",
-            m1d_dataitem,
-        )
-
-    def set_gridpoints(self, reach):
-        """Assign chainage attributes to a current ResultReach object from a data provided by IRes1DReach.
-
-        Parameters
-        ----------
-        reach: IRes1DReach
-            A MIKE 1D IRes1DReach object.
-
-        """
-        current_reach_result_gridpoints = []
-        self.current_reach_result_gridpoints = current_reach_result_gridpoints
-        self.result_gridpoints.append(current_reach_result_gridpoints)
-
-        # For SWMM and EPANET results no grid points are defined
-        # so introduce a single one.
-        gridpoint_count = reach.GridPoints.Count
-        if gridpoint_count == 0:
-            gridpoint = Res1DGridPoint()
-            self.set_gridpoint(reach, gridpoint)
-
-        gridpoints = list(reach.GridPoints)
-        tag = self.create_reach_span_tag(gridpoints)
-        for i in range(gridpoint_count):
-            gridpoint = gridpoints[i]
-            self.set_gridpoint(reach, gridpoint, tag)
-
-    def create_reach_span_tag(self, gridpoints):
-        """Create reach span tag to be set on ResultGridPoint."""
-        if len(gridpoints) == 0:
-            return ""
-
-        start_gp = gridpoints[0]
-        end_gp = gridpoints[-1]
-        tag = TimeSeriesId.create_reach_span_tag_from_gridpoints(start_gp, end_gp)
-        return tag
-
-    def set_gridpoint(self, reach, gridpoint, tag=""):
-        """Assign chainage attribute to a current ResultReach object from a data provided by IRes1DReach and IRes1DGridPoint.
-
-        Parameters
-        ----------
-        reach: IRes1DReach
-            A MIKE 1D IRes1DReach object.
-        gridpoint: IRes1DGridPoint
-            A MIKE 1D IRes1DGridPoint object.
-
-        """
-        current_reach_result_gridpoints = self.current_reach_result_gridpoints
-
-        result_gridpoint = ResultGridPoint(reach, gridpoint, reach.DataItems, self, self.res1d, tag)
-        current_reach_result_gridpoints.append(result_gridpoint)
-
-        chainage_string = f"{gridpoint.Chainage:g}"
-        result_gridpoint_attribute_string = make_proper_variable_name(
-            chainage_string, self.chainage_label
-        )
-        setattr(self, result_gridpoint_attribute_string, result_gridpoint)
-
-        chainage_str = f"{gridpoint.Chainage:.3f}"
-        self[chainage_str] = result_gridpoint
-
-    def set_gridpoint_data_items(self, reach):
-        """Assign data items to ResultGridPoint object belonging to current ResultReach from IRes1DReach data items.
-
-        Parameters
-        ----------
-        reach: IRes1DReach
-            A MIKE 1D IRes1DReach object.
-
-        """
-        for data_item in reach.DataItems:
-            # For SWMM and EPANET results IndexList is None.
-            index_list = [0] if data_item.IndexList is None else list(data_item.IndexList)
-            element_count = len(index_list)
-            for element_index in range(element_count):
-                gridpoint_index = index_list[element_index]
-                result_gridpoint = self.current_reach_result_gridpoints[gridpoint_index]
-                if data_item.ItemId is None:
-                    result_gridpoint.add_data_item(data_item, element_index)
-                else:
-                    result_gridpoint.add_structure_data_item(data_item)
-
-    def get_query(self, data_item):
-        """Get a query for a data item."""
-        raise NotImplementedError("get_query not implemented for ResultReach. Use ResultGridPoint.")
-
-    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
-        """Add a quantity to the result quantity maps."""
-        raise NotImplementedError(
-            "add_to_result_quantity_maps not implemented for ResultReach. Use ResultGridPoint."
-        )
-
-    @property
-    def geometry(self) -> ReachGeometry:
-        """A geometric representation of the reach. Requires shapely."""
-        try_import_shapely()
-        from ..geometry import ReachGeometry
-
-        return ReachGeometry.from_m1d_reaches(self.reaches)
-
-    @property
-    def name(self) -> str:
-        """Name of the reach."""
-        return self.reaches[0].Name
-
-    @property
-    def length(self) -> float | None:
-        """Length of the reach."""
-        return self._get_total_length()
-
-    @property
-    def start_chainage(self) -> float:
-        """Start chainage of the reach."""
-        return self.reaches[0].LocationSpan.StartChainage
-
-    @property
-    def end_chainage(self) -> float:
-        """End chainage of the reach."""
-        return self.reaches[-1].LocationSpan.EndChainage
-
-    @property
-    def n_gridpoints(self) -> int:
-        """Number of gridpoints in the reach."""
-        return self._get_total_gridpoints()
-
-    @property
-    def start_node(self) -> str | None:
-        """Start node of the reach."""
-        # For resx files, the start and end node indices are not available
-        if self.res1d.file_path.endswith(".resx"):
-            return None
-        return self._get_start_node()
-
-    @property
-    def end_node(self) -> str:
-        """End node of the reach."""
-        # For resx files, the start and end node indices are not available
-        if self.res1d.file_path.endswith(".resx"):
-            return None
-        return self._get_end_node()
-
-    @property
-    def height(self) -> float:
-        """Height of the reach."""
-        return self._get_height()
-
-    @property
-    def full_flow_discharge(self) -> float:
-        """Full flow discharge of the reach."""
-        return self._get_full_flow_discharge()
-
-    def interpolate_reach_ground_level(self, chainage: float) -> float:
-        """Interpolate the ground level at a given chainage by linear interpolation from the bounding node ground levels.
-
-        Parameters
-        ----------
-        chainage: float
-            Chainage for which to interpolate the ground level.
-
-        Returns
-        -------
-        float
-            Interpolated ground level.
-
-        """
+    def _interpolate_reach_ground_level(self, chainage: float) -> float:
         reach = self._get_reach_for_chainage(chainage)
         start_chainage = reach.LocationSpan.StartChainage
         end_chainage = reach.LocationSpan.EndChainage
@@ -404,20 +459,7 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
         ground_slope = (end_ground_level - start_ground_level) / (end_chainage - start_chainage)
         return start_ground_level + ground_slope * (chainage - start_chainage)
 
-    def interpolate_reach_critical_level(self, chainage: float) -> float:
-        """Interpolate the critical level at a given chainage by linear interpolation from the bounding node critical levels.
-
-        Parameters
-        ----------
-        chainage: float
-            Chainage for which to interpolate the critical level.
-
-        Returns
-        -------
-        float
-            Interpolated critical level.
-
-        """
+    def _interpolate_reach_critical_level(self, chainage: float) -> float:
         reach = self._get_reach_for_chainage(chainage)
         start_chainage = reach.LocationSpan.StartChainage
         end_chainage = reach.LocationSpan.EndChainage

--- a/mikeio1d/result_network/result_reach.py
+++ b/mikeio1d/result_network/result_reach.py
@@ -87,38 +87,6 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
         """List of gridpoints for the reach."""
         return list(self.values())
 
-    def get_m1d_dataset(self, m1d_dataitem=None):
-        """Get IRes1DDataSet object associated with ResultReach.
-
-        A ResultReach may consist of several IRes1DDataSet objects. Therefore,
-        a IRes1DDataItem must be provided to identify the correct IRes1DDataSet.
-
-        Parameters
-        ----------
-        m1d_dataitem: IDataItem
-            The IRes1DDataItem associated with the returned IRes1DDataSet.
-
-        Returns
-        -------
-        IRes1DDataSet
-            IRes1DDataSet object associated with ResultReach.
-
-        """
-        if m1d_dataitem is None:
-            raise ValueError("m1d_dataitem must be provided for ResultReach.")
-
-        for m1d_reach in self.reaches:
-            if m1d_reach.DataItems.Contains(m1d_dataitem):
-                return m1d_reach
-        raise Exception(
-            "No IRes1DDataSet found on reach for specified IRes1DDataItem: ",
-            m1d_dataitem,
-        )
-
-    def get_query(self, data_item):
-        """Get a query for a data item."""
-        raise NotImplementedError("get_query not implemented for ResultReach. Use ResultGridPoint.")
-
     @property
     def geometry(self) -> ReachGeometry:
         """A geometric representation of the reach. Requires shapely."""
@@ -177,6 +145,38 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
     def full_flow_discharge(self) -> float:
         """Full flow discharge of the reach."""
         return self._creator._get_full_flow_discharge()
+
+    def get_m1d_dataset(self, m1d_dataitem=None):
+        """Get IRes1DDataSet object associated with ResultReach.
+
+        A ResultReach may consist of several IRes1DDataSet objects. Therefore,
+        a IRes1DDataItem must be provided to identify the correct IRes1DDataSet.
+
+        Parameters
+        ----------
+        m1d_dataitem: IDataItem
+            The IRes1DDataItem associated with the returned IRes1DDataSet.
+
+        Returns
+        -------
+        IRes1DDataSet
+            IRes1DDataSet object associated with ResultReach.
+
+        """
+        if m1d_dataitem is None:
+            raise ValueError("m1d_dataitem must be provided for ResultReach.")
+
+        for m1d_reach in self.reaches:
+            if m1d_reach.DataItems.Contains(m1d_dataitem):
+                return m1d_reach
+        raise Exception(
+            "No IRes1DDataSet found on reach for specified IRes1DDataItem: ",
+            m1d_dataitem,
+        )
+
+    def get_query(self, data_item):
+        """Get a query for a data item."""
+        raise NotImplementedError("get_query not implemented for ResultReach. Use ResultGridPoint.")
 
     def interpolate_reach_ground_level(self, chainage: float) -> float:
         """Interpolate the ground level at a given chainage by linear interpolation from the bounding node ground levels.

--- a/mikeio1d/result_network/result_reaches.py
+++ b/mikeio1d/result_network/result_reaches.py
@@ -9,12 +9,14 @@ if TYPE_CHECKING:  # pragma: no cover
     from typing import Dict
     from geopandas import GeoDataFrame
 
-from .result_locations import ResultLocations
-from .result_reach import ResultReach
-from .various import make_proper_variable_name
 from ..dotnet import pythonnet_implementation as impl
 from ..pandas_extension import ResultFrameAggregator
 from ..quantities import TimeSeriesIdGroup
+
+from .result_locations import ResultLocations
+from .result_locations import ResultLocationsCreator
+from .result_reach import ResultReach
+from .various import make_proper_variable_name
 
 
 class ResultReaches(ResultLocations):
@@ -30,62 +32,16 @@ class ResultReaches(ResultLocations):
     res1d : Res1D
         Res1D object the reaches belong to.
 
-    Attributes
-    ----------
-    reach_label : str
-        A label, which is appended if the reach name starts
-        with a number. The value used is reach_label = 'r_'
-    result_reach_map : dict
-        Dictionary from reach name to a list of ResultReach objects.
-        This is needed, because the reach name is not necessarily unique and
-        several reaches could have the same name.
-
     """
 
     def __init__(self, res1d):
-        ResultLocations.__init__(self, res1d)
-        self._group = TimeSeriesIdGroup.REACH
-        self.reach_label = "r_"
-        self.result_reach_map = {}
+        ResultLocations.__init__(self)
 
         res1d.network.reaches = self
-        self.set_reaches()
-        self.set_quantity_collections()
+        self._group = TimeSeriesIdGroup.REACH
 
-    def set_reaches(self):
-        """Set attributes to the current ResultReaches object based on the reach name."""
-        for reach in self.data.Reaches:
-            if not self.res1d.reader.is_data_set_included(reach):
-                continue
-            reach = impl(reach)
-            result_reach = self.get_or_create_result_reach(reach)
-            result_reach_attribute_string = make_proper_variable_name(reach.Name, self.reach_label)
-            setattr(self, result_reach_attribute_string, result_reach)
-
-    def set_quantity_collections(self):
-        """Set quantity collections to the current ResultReaches object."""
-        ResultLocations.set_quantity_collections(self)
-        for reach_name in self:
-            result_reach = self[reach_name]
-            ResultLocations.set_quantity_collections(result_reach)
-
-    def get_or_create_result_reach(self, reach):
-        """Create or get already existing ResultReach object.
-
-        There potentially could be just a single ResultReach object,
-        for many IRes1DReach object, which have the same name.
-
-        Also update self's dict entry from reach name
-        to a ResultReach object.
-        """
-        if reach.Name in self:
-            result_reach = self[reach.Name]
-            result_reach.add_res1d_reach(reach)
-            return result_reach
-
-        result_reach = ResultReach([reach], self.res1d)
-        self[reach.Name] = result_reach
-        return result_reach
+        self._creator = ResultReachesCreator(self, res1d)
+        self._creator.create()
 
     def to_geopandas(
         self,
@@ -157,3 +113,73 @@ class ResultReaches(ResultLocations):
             gdf = gdf.merge(df_quantities, left_on="name", right_index=True)
 
         return gdf
+
+
+class ResultReachesCreator(ResultLocationsCreator):
+    """A helper class for creating ResultReaches.
+
+    Parameters
+    ----------
+    result_locations : ResultReaches
+        Instance of ResultReaches, which the ResultReachesCreator deals with.
+    res1d : Res1D
+        Res1D object the reaches belong to.
+
+    Attributes
+    ----------
+    reach_label : str
+        A label, which is appended if the reach name starts
+        with a number. The value used is reach_label = 'r_'
+    result_reach_map : dict
+        Dictionary from reach name to a list of ResultReach objects.
+        This is needed, because the reach name is not necessarily unique and
+        several reaches could have the same name.
+
+    """
+
+    def __init__(self, result_locations, res1d):
+        ResultLocationsCreator.__init__(self, result_locations, res1d)
+        self.reach_label = "r_"
+        self.result_reach_map = {}
+
+    def create(self):
+        """Perform ResultReaches creation steps."""
+        self.set_reaches()
+        self.set_quantity_collections()
+
+    def set_reaches(self):
+        """Set attributes to the current ResultReaches object based on the reach name."""
+        for reach in self.data.Reaches:
+            # TODO: Figure out if we should we have res1d.reader dependency here?
+            if not self.res1d.reader.is_data_set_included(reach):
+                continue
+
+            reach = impl(reach)
+            result_reach = self.get_or_create_result_reach(reach)
+            result_reach_attribute_string = make_proper_variable_name(reach.Name, self.reach_label)
+            setattr(self.result_locations, result_reach_attribute_string, result_reach)
+
+    def set_quantity_collections(self):
+        """Set quantity collections to the current ResultReaches object."""
+        ResultLocationsCreator.set_quantity_collections(self)
+        for reach_name in self.result_locations:
+            result_reach = self.result_locations[reach_name]
+            ResultLocationsCreator.set_quantity_collections(result_reach._creator, result_reach)
+
+    def get_or_create_result_reach(self, reach):
+        """Create or get already existing ResultReach object.
+
+        There potentially could be just a single ResultReach object,
+        for many IRes1DReach object, which have the same name.
+
+        Also update self's dict entry from reach name
+        to a ResultReach object.
+        """
+        if reach.Name in self.result_locations:
+            result_reach = self.result_locations[reach.Name]
+            result_reach._creator.add_res1d_reach(reach)
+            return result_reach
+
+        result_reach = ResultReach([reach], self.res1d)
+        self.result_locations[reach.Name] = result_reach
+        return result_reach

--- a/mikeio1d/result_network/result_reaches.py
+++ b/mikeio1d/result_network/result_reaches.py
@@ -6,8 +6,13 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Callable
+    from typing import List
     from typing import Dict
     from geopandas import GeoDataFrame
+
+    from ..res1d import Res1D
+
+    from DHI.Mike1D.ResultDataAccess import IRes1DReach
 
 from ..dotnet import pythonnet_implementation as impl
 from ..pandas_extension import ResultFrameAggregator
@@ -34,7 +39,7 @@ class ResultReaches(ResultLocations):
 
     """
 
-    def __init__(self, res1d):
+    def __init__(self, res1d: Res1D):
         ResultLocations.__init__(self)
 
         res1d.network.reaches = self
@@ -137,10 +142,10 @@ class ResultReachesCreator(ResultLocationsCreator):
 
     """
 
-    def __init__(self, result_locations, res1d):
+    def __init__(self, result_locations: ResultReaches, res1d: Res1D):
         ResultLocationsCreator.__init__(self, result_locations, res1d)
         self.reach_label = "r_"
-        self.result_reach_map = {}
+        self.result_reach_map: Dict[str : List[ResultReach]] = {}
 
     def create(self):
         """Perform ResultReaches creation steps."""
@@ -166,7 +171,7 @@ class ResultReachesCreator(ResultLocationsCreator):
             result_reach = self.result_locations[reach_name]
             ResultLocationsCreator.set_quantity_collections(result_reach._creator, result_reach)
 
-    def get_or_create_result_reach(self, reach):
+    def get_or_create_result_reach(self, reach: IRes1DReach) -> ResultReach:
         """Create or get already existing ResultReach object.
 
         There potentially could be just a single ResultReach object,

--- a/mikeio1d/result_network/result_structure.py
+++ b/mikeio1d/result_network/result_structure.py
@@ -71,6 +71,21 @@ class ResultStructure(ResultLocation):
         )
         return self.id
 
+    @property
+    def id(self) -> str:
+        """Structure ID."""
+        return self._id
+
+    @property
+    def type(self) -> str:
+        """Type of the structure."""
+        return self.reach.Name.split(":")[0]
+
+    @property
+    def chainage(self) -> float:
+        """Chainage of the structure."""
+        return self._chainage
+
     def get_m1d_dataset(self, m1d_dataitem=None):
         """Get IRes1DDataSet object associated with ResultStructure.
 
@@ -96,21 +111,6 @@ class ResultStructure(ResultLocation):
         structure_id = self.id
         query = QueryDataStructure(quantity_id, structure_id, self.reach.Name, self._chainage)
         return query
-
-    @property
-    def id(self) -> str:
-        """Structure ID."""
-        return self._id
-
-    @property
-    def type(self) -> str:
-        """Type of the structure."""
-        return self.reach.Name.split(":")[0]
-
-    @property
-    def chainage(self) -> float:
-        """Chainage of the structure."""
-        return self._chainage
 
 
 class ResultStructureCreator(ResultLocationCreator):

--- a/mikeio1d/result_network/result_structure.py
+++ b/mikeio1d/result_network/result_structure.py
@@ -1,11 +1,20 @@
 """Module for ResultStructure class."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from DHI.Mike1D.ResultDataAccess import IRes1DReach
+
 from warnings import warn
 
 from ..dotnet import pythonnet_implementation as impl
 from ..query import QueryDataStructure
-from .result_location import ResultLocation
 from ..quantities import TimeSeriesIdGroup
+
+from .result_location import ResultLocation
+from .result_location import ResultLocationCreator
 
 
 class ResultStructure(ResultLocation):
@@ -32,25 +41,26 @@ class ResultStructure(ResultLocation):
     """
 
     def __init__(self, structure_id, reach, data_items, res1d):
-        empty_list = []
-        ResultLocation.__init__(self, empty_list, res1d)
+        ResultLocation.__init__(self)
 
         self._group = TimeSeriesIdGroup.STRUCTURE
         self._name = structure_id
         self._tag = reach.Name
         self._id = structure_id
-        self.reach = reach
         self._chainage = None
 
-        self.data_items_dict = {}
-        for data_item in data_items:
-            self.add_res1d_structure_data_item(data_item)
-
-        self.set_static_attributes()
+        self._creator = ResultStructureCreator(self, reach, data_items, res1d)
+        self._creator.create()
 
     def __repr__(self) -> str:
         """Return a string representation of ResultStructure."""
         return f"<{self.type}: {self.id}>"
+
+    @property
+    def reach(self) -> IRes1DReach:
+        """IRes1DReach corresponding to this result structure."""
+        # TODO: Consider to remove or rename this property to res1d_reach for version 1.0.0
+        return self._creator.reach
 
     @property
     def structure_id(self):
@@ -80,58 +90,6 @@ class ResultStructure(ResultLocation):
         """
         return self.reach
 
-    def set_static_attributes(self):
-        """Set static attributes. These show up in the html repr."""
-        self.set_static_attribute("id")
-        self.set_static_attribute("type")
-        self.set_static_attribute("chainage")
-
-    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
-        """Add structure result quantity to result quantity maps."""
-        self.add_to_result_quantity_map(quantity_id, result_quantity, self.result_quantity_map)
-
-        structure_result_quantity_map = self.res1d.network.structures.result_quantity_map
-        self.add_to_result_quantity_map(quantity_id, result_quantity, structure_result_quantity_map)
-
-        self.add_to_network_result_quantity_map(result_quantity)
-
-    def add_res1d_structure_data_item(self, data_item):
-        """Add a IDataItem to ResultStructure.
-
-        Parameters
-        ----------
-        data_item: IDataItem
-            A MIKE 1D IDataItem object.
-
-        """
-        if self._chainage is None:
-            index_list = list(data_item.IndexList)
-            gridpoint_index = index_list[0]
-            gridpoints = list(self.reach.GridPoints)
-            self._chainage = gridpoints[gridpoint_index].Chainage
-
-        self.data_items.append(data_item)
-        self.data_items_dict[data_item.Quantity.Id] = data_item
-        self.set_quantity(self, data_item)
-
-    @staticmethod
-    def get_structure_id(reach, data_item):
-        """Get structure ID either from IDataItem.ItemId or for structure reaches from actual Res1DStructureGridPoint structure."""
-        if data_item.ItemId is not None:
-            return data_item.ItemId
-
-        if reach.IsStructureReach:
-            structure_gridpoint = impl(list(reach.GridPoints)[1])
-            structures = list(structure_gridpoint.Structures)
-            structure_id = structures[0].Id
-            return structure_id
-
-        return None
-
-    def get_data_item(self, quantity_id):
-        """Retrieve a data item for given quantity id."""
-        return self.data_items_dict[quantity_id]
-
     def get_query(self, data_item):
         """Get a QueryDataStructure for given data item."""
         quantity_id = data_item.Quantity.Id
@@ -153,3 +111,98 @@ class ResultStructure(ResultLocation):
     def chainage(self) -> float:
         """Chainage of the structure."""
         return self._chainage
+
+
+class ResultStructureCreator(ResultLocationCreator):
+    """Helper class for creating ResultGridPoint.
+
+    Parameters
+    ----------
+    result_location : ResultGridPoint
+        Instance of ResultGridPoint, which the ResultGridPointCreator deals with.
+    reach: IRes1DReach
+        MIKE 1D IRes1DReach object.
+    gridpoint IRes1DGridPoint
+        MIKE 1D IRes1DGridPoint object.
+    data_items : list of IDataItem objects
+        A list of IDataItem objects (vector data object) the
+        gridpoint has values defined on.
+    result_reach : ResultReach
+        Instance of ResultReach that this ResultGridPoint belongs to.
+    res1d : Res1D
+        Res1D object the grid point belongs to.
+
+    Attributes
+    ----------
+    structure_data_items : list of IDataItem object.
+        List of IDataItem objects belonging to a structures
+        defined on the current grid point.
+
+    """
+
+    def __init__(self, result_location, reach, data_items, res1d):
+        empty_data_item_list = []
+        ResultLocationCreator.__init__(self, result_location, empty_data_item_list, res1d)
+
+        self.data_items_intial = data_items
+        self.reach = reach
+        self.data_items_dict = {}
+
+    def create(self):
+        """Perform ResultGridPoint creation steps."""
+        for data_item in self.data_items_intial:
+            self.add_res1d_structure_data_item(data_item)
+
+        self.set_static_attributes()
+
+    def set_static_attributes(self):
+        """Set static attributes. These show up in the html repr."""
+        self.set_static_attribute("id")
+        self.set_static_attribute("type")
+        self.set_static_attribute("chainage")
+
+    def add_to_result_quantity_maps(self, quantity_id, result_quantity):
+        """Add structure result quantity to result quantity maps."""
+        self.add_to_result_quantity_map(quantity_id, result_quantity, self.result_quantity_map)
+
+        structure_result_quantity_map = self.res1d.network.structures._creator.result_quantity_map
+        self.add_to_result_quantity_map(quantity_id, result_quantity, structure_result_quantity_map)
+
+        self.add_to_network_result_quantity_map(result_quantity)
+
+    def add_res1d_structure_data_item(self, data_item):
+        """Add a IDataItem to ResultStructure.
+
+        Parameters
+        ----------
+        data_item: IDataItem
+            A MIKE 1D IDataItem object.
+
+        """
+        if self.result_location._chainage is None:
+            index_list = list(data_item.IndexList)
+            gridpoint_index = index_list[0]
+            gridpoints = list(self.reach.GridPoints)
+            self.result_location._chainage = gridpoints[gridpoint_index].Chainage
+
+        self.data_items.append(data_item)
+        self.data_items_dict[data_item.Quantity.Id] = data_item
+        self.set_quantity(self.result_location, data_item)
+
+    @staticmethod
+    def get_structure_id(reach, data_item):
+        """Get structure ID either from IDataItem.ItemId or for structure reaches from actual Res1DStructureGridPoint structure."""
+        if data_item.ItemId is not None:
+            return data_item.ItemId
+
+        if reach.IsStructureReach:
+            structure_gridpoint = impl(list(reach.GridPoints)[1])
+            structures = list(structure_gridpoint.Structures)
+            structure_id = structures[0].Id
+            return structure_id
+
+        return None
+
+    def get_data_item(self, quantity_id):
+        """Retrieve a data item for given quantity id."""
+        return self.data_items_dict[quantity_id]

--- a/mikeio1d/result_network/result_structures.py
+++ b/mikeio1d/result_network/result_structures.py
@@ -1,5 +1,19 @@
 """Module for ResultStructures class."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import List
+    from typing import Dict
+
+    from ..res1d import Res1D
+    from .result_quantity import ResultQuantity
+
+    from DHI.Mike1D.ResultDataAccess import IDataItem
+    from DHI.Mike1D.ResultDataAccess import IRes1DReach
+
 from ..quantities import TimeSeriesIdGroup
 
 from .result_locations import ResultLocations
@@ -22,7 +36,7 @@ class ResultStructures(ResultLocations):
 
     """
 
-    def __init__(self, res1d):
+    def __init__(self, res1d: Res1D):
         ResultLocations.__init__(self)
 
         res1d.network.structures = self
@@ -52,10 +66,10 @@ class ResultStructuresCreator(ResultLocationsCreator):
 
     """
 
-    def __init__(self, result_locations, res1d):
+    def __init__(self, result_locations: ResultStructures, res1d: Res1D):
         ResultLocationsCreator.__init__(self, result_locations, res1d)
         self.structure_label = "s_"
-        self.result_structure_map = {}
+        self.result_structure_map: Dict[str, ResultStructure] = {}
 
     def create(self):
         """Perform ResultStructures creation steps."""
@@ -79,7 +93,7 @@ class ResultStructuresCreator(ResultLocationsCreator):
                 )
                 setattr(self.result_locations, result_structure_attribute_string, result_structure)
 
-    def is_structure(self, reach, data_item):
+    def is_structure(self, reach: IRes1DReach, data_item: IDataItem) -> bool:
         """Check if a data item is a structure data item."""
         # Data items on reaches with defined ItemId correspond to structure data items.
         if data_item.ItemId is not None:
@@ -97,7 +111,9 @@ class ResultStructuresCreator(ResultLocationsCreator):
 
         return False
 
-    def get_or_create_result_structure(self, reach, data_item):
+    def get_or_create_result_structure(
+        self, reach: IRes1DReach, data_item: IDataItem
+    ) -> ResultStructure:
         """Create or get already existing ResultStructure object.
 
         Also update a result_structure_map dict entry from structure ID

--- a/mikeio1d/result_query/query_data_structure.py
+++ b/mikeio1d/result_query/query_data_structure.py
@@ -55,7 +55,7 @@ class QueryDataStructure(QueryDataReach):
         result_structure = self._get_result_structure(res1d)
 
         self._check_invalid_structure_quantity(result_structure)
-        data_item = result_structure.get_data_item(self._quantity)
+        data_item = result_structure._creator.get_data_item(self._quantity)
 
         values = data_item.CreateTimeSeriesData(0)
 
@@ -107,7 +107,7 @@ class QueryDataStructure(QueryDataReach):
             raise InvalidStructure(str(self))
 
     def _check_invalid_structure_quantity(self, result_structure):
-        if self._quantity not in result_structure.data_items_dict:
+        if self._quantity not in result_structure._creator.data_items_dict:
             raise InvalidQuantity(str(self))
 
     def _update_location_info(self, result_structure):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -72,7 +72,9 @@ def node(res1d_network):
 @pytest.fixture
 def many_nodes(res1d_network):
     nodes = res1d_network.network.nodes
-    return [getattr(nodes, n) for n in nodes.__dict__.keys() if n.startswith(nodes.node_label)]
+    return [
+        getattr(nodes, n) for n in nodes.__dict__.keys() if n.startswith(nodes._creator.node_label)
+    ]
 
 
 @pytest.fixture
@@ -89,7 +91,9 @@ def river_reach(res1d_river_network):
 def many_reaches(res1d_network):
     reaches = res1d_network.network.reaches
     return [
-        getattr(reaches, r) for r in reaches.__dict__.keys() if r.startswith(reaches.reach_label)
+        getattr(reaches, r)
+        for r in reaches.__dict__.keys()
+        if r.startswith(reaches._creator.reach_label)
     ]
 
 
@@ -105,7 +109,7 @@ def many_catchments(res1d_catchments):
     return [
         getattr(catchments, c)
         for c in catchments.__dict__.keys()
-        if c.startswith(catchments.catchment_label)
+        if c.startswith(catchments._creator.catchment_label)
     ]
 
 

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -130,7 +130,7 @@ class TestReachGeometry:
 
 
 def test_geometry_from_node(node):
-    node = NodePoint.from_res1d_node(node._node)
+    node = NodePoint.from_res1d_node(node.node)
     g = node.to_shapely()
     assert isinstance(g, shapely.Point)
     assert g.x == pytest.approx(-687934.6000976562)
@@ -139,7 +139,7 @@ def test_geometry_from_node(node):
 
 def test_geometry_from_catchment(many_catchments):
     for catchment in many_catchments:
-        catchment_geom = CatchmentGeometry.from_res1d_catchment(catchment._catchment)
+        catchment_geom = CatchmentGeometry.from_res1d_catchment(catchment.catchment)
         g = catchment_geom.to_shapely()
         assert isinstance(g, shapely.Polygon)
         assert (g.centroid.x, g.centroid.y) == pytest.approx(
@@ -149,7 +149,7 @@ def test_geometry_from_catchment(many_catchments):
 
 def test_geometry_from_nodes_runs(many_nodes):
     for node in many_nodes:
-        node = NodePoint.from_res1d_node(node._node)
+        node = NodePoint.from_res1d_node(node.node)
         g = node.to_shapely()
         assert isinstance(g, shapely.Point)
 
@@ -162,6 +162,6 @@ def test_geometry_from_reaches_runs(many_reaches):
 
 def test_geometry_from_catchments_runs(many_catchments):
     for catchment in many_catchments:
-        catchment = CatchmentGeometry.from_res1d_catchment(catchment._catchment)
+        catchment = CatchmentGeometry.from_res1d_catchment(catchment.catchment)
         g = catchment.to_shapely()
         assert isinstance(g, shapely.Polygon)

--- a/tests/test_res1d_network_river.py
+++ b/tests/test_res1d_network_river.py
@@ -385,4 +385,4 @@ def test_result_quantity_collection_methods(test_file):
 
 def test_calculate_total_reach_lengths(res1d_river_network):
     reach = res1d_river_network.reaches.river
-    assert reach._get_total_length() == pytest.approx(2024.22765)
+    assert reach._creator._get_total_length() == pytest.approx(2024.22765)


### PR DESCRIPTION
The code related to creation of ResultLocation classes is moved to ResultLocationCreator in order to clean-up public API. 

- Currently an instance of ResultLocationCreator lives inside ResultLocation. Eventually it could make sense to invert this dependency and make ResultLocationCreator actually create instance of ResultLocation.
- ResultLocationCreator not only creates ResultLocation, but also performs some handling. Eventually we could split this into ResultLocationHandler.
- A IRes1DDataSet properties are introduced to access MIKE 1D .NET instances. For release 1.0.0 we should either remove them and use `get_m1d_dataset()` or rename them to res1d_node, res1d_catchment, etc.