### PR TITLE
Cannot save results loaded with filter

### DIFF
--- a/mikeio1d/res1d.py
+++ b/mikeio1d/res1d.py
@@ -71,6 +71,7 @@ from .pandas_extension import Mikeio1dAccessor  # noqa: F401
 
 from System import DateTime
 from DHI.Mike1D.Generic import Connection
+from DHI.Mike1D.ResultDataAccess import Res1DExtensions
 
 
 class Res1D:
@@ -308,6 +309,7 @@ class Res1D:
         self.reader.load_dynamic_data()
         connection_original = self.result_data.Connection
         self.result_data.Connection = Connection.Create(file_path)
+        Res1DExtensions.RemoveUnusedDataItems(self.result_data)
         self.result_data.Save()
         self.result_data.Connection = connection_original
 

--- a/tests/test_various.py
+++ b/tests/test_various.py
@@ -1,6 +1,7 @@
 import os
 import pytest
 
+import mikeio1d
 from mikeio1d import Res1D
 from mikeio1d.result_network.various import make_proper_variable_name
 
@@ -16,6 +17,13 @@ def test_file_path():
 def test_file_path_res11():
     test_folder_path = os.path.dirname(os.path.abspath(__file__))
     return os.path.join(test_folder_path, "testdata", "network_cali.res11")
+
+
+@pytest.fixture
+def test_file_path2():
+    test_folder_path = os.path.dirname(os.path.abspath(__file__))
+    # Original file name was Exam6Base.res1d
+    return os.path.join(test_folder_path, "testdata", "network.res1d")
 
 
 def test_make_proper_variable_name():
@@ -71,3 +79,16 @@ def test_res11_to_res1d_conversion(test_file_path_res11):
     df_res1d = res1d.read()
 
     assert df_res11.max().max() == df_res1d.max().max()
+
+
+def test_saving_with_filter(test_file_path2):
+    res_unfiltered = mikeio1d.open(test_file_path2)
+    assert res_unfiltered.quantities == ["WaterLevel", "Discharge"]
+
+    res_filtered = mikeio1d.open(test_file_path2, quantities=["WaterLevel"])
+    res_filtered.save("filtered.res1d")
+
+    res_filtered = mikeio1d.open("filtered.res1d")
+    assert res_filtered.quantities == ["WaterLevel"]
+
+    os.remove("filtered.res1d")


### PR DESCRIPTION
When loading a Res1D file with a quantity filter, there's issues saving the file afterwards:

```
res = mikeio1d.open("some_file.res1d", quantities=["WaterLevel"])
res.save("subset.res1d")
```

This PR fixes that issue
