### PR TITLE
Bug/index reach with chainage float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@
 
 ### Changed
 
+## [1.1.1] - 2025-06-02
+
+### Added
+- Added support for indexing ResultReach with float chainage values
+
 ## [1.1.0] - 2025-06-01
 
 ### Added

--- a/mikeio1d/__init__.py
+++ b/mikeio1d/__init__.py
@@ -24,7 +24,7 @@ from .mikepath import MikePath
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.1.0"
+__version__ = "1.1.1"
 
 if "64" not in platform.architecture()[0]:
     raise Exception("This library has not been tested for a 32 bit system.")

--- a/mikeio1d/result_network/result_reach.py
+++ b/mikeio1d/result_network/result_reach.py
@@ -91,7 +91,7 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
                 except ValueError:
                     continue
 
-            raise KeyError(f"Chainage {key} not found in reach. Available chainages: {self.chainages}")
+            raise KeyError(f"Chainage {key} not found in reach. Available chainages: {self.chainages}\nNote: Integer indices (e.g., reach[10]) access by position, while float indices (e.g., reach[10.0]) access by chainage value.")
             
         return super().__getitem__(key)
 

--- a/mikeio1d/result_network/result_reach.py
+++ b/mikeio1d/result_network/result_reach.py
@@ -60,10 +60,39 @@ class ResultReach(ResultLocation, Dict[str, ResultGridPoint]):
         """Return a string representation of ResultReach."""
         return f"<Reach: {self.name}>"
 
-    def __getitem__(self, key: str | int) -> ResultGridPoint:
-        """Get a ResultGridPoint object by chainage."""
+    def __getitem__(self, key: str | int | float) -> ResultGridPoint:
+        """Get a ResultGridPoint object by chainage.
+        
+        Parameters
+        ----------
+        key : str | int | float
+            If int: index in gridpoints list
+            If str: chainage as string
+            If float: chainage as float, will be converted to string
+            
+        Returns
+        -------
+        ResultGridPoint
+            The grid point at the specified chainage or index
+        """
         if isinstance(key, int):
             return self.gridpoints[key]
+        elif isinstance(key, float):          
+            key_str = str(key)
+            if key_str in self:
+                return super().__getitem__(key_str)
+            
+            for chainage_str in self.chainages:
+                try:
+                    chainage_float = float(chainage_str)
+                    epsilon = 1e-1
+                    if abs(chainage_float - key) < epsilon:
+                        return super().__getitem__(chainage_str)
+                except ValueError:
+                    continue
+
+            raise KeyError(f"Chainage {key} not found in reach. Available chainages: {self.chainages}")
+            
         return super().__getitem__(key)
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ exclude = ["notebooks", "tests", "images"]
 
 [project]
 name = "mikeio1d"
-version = "1.1.0"
+version = "1.1.1"
 description = "A package that uses the DHI MIKE1D .NET libraries to read res1d and xns11 files."
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_res1d_network.py
+++ b/tests/test_res1d_network.py
@@ -444,6 +444,46 @@ def test_structure_reach_static_attributes(res1d_network):
     assert structures.s_115p1.chainage == pytest.approx(41.21402714094492)
 
 
+@pytest.mark.parametrize(
+    "str_chainage,float_chainage",
+    [
+        ("0.000", 0.0),       # Exact match
+        ("23.841", 23.841),   # Exact match
+        ("23.841", 23.84),    # Fewer decimal places
+        ("23.841", 23.8),     # Fewer decimal places
+        ("47.683", 47.683),   # Exact match for last chainage
+        ("47.683", 47.68),    # Fewer decimal places
+        ("47.683", 47.6),    # Fewer decimal places
+    ],
+)
+def test_reach_float_chainage_indexing(test_file, str_chainage, float_chainage):
+    """Test that ResultReach can be indexed with a float chainage value.
+    
+    Uses reach 100l1 with chainages ['0.000', '23.841', '47.683']
+    """
+    res1d = test_file
+    reaches = res1d.reaches
+    reach = reaches.r_100l1
+    
+    # Get grid points using both string and float representations
+    grid_point_from_str = reach[str_chainage]
+    grid_point_from_float = reach[float_chainage]
+    
+    # Assert they are the same grid point
+    assert grid_point_from_float is grid_point_from_str
+
+
+def test_reach_float_chainage_indexing_keyerror(test_file):
+    """Test that trying to access a non-existent chainage raises KeyError."""
+    res1d = test_file
+    reaches = res1d.reaches
+    reach = reaches.r_100l1
+    
+    # Test that trying to access a non-existent chainage raises KeyError
+    with pytest.raises(KeyError):
+        reach[999.999]
+
+
 def test_to_dataframe_aliases(res1d_network):
     """Test that to_dataframe() alias exists and returns a DataFrame in all relevant classes."""
     # Test Res1D class


### PR DESCRIPTION
Both of these should be valid, but only the string version is:

```python
res.reaches["my_reach"]["100.000"]
``` 

```python
res.reaches["my_reach"][100.000]
``` 