### PR TITLE
Bump .NET SDK from 6.0 to 8.0 in CI

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -35,8 +35,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '6.0.x'
-    
+        dotnet-version: '8.0.x'
     - name: Install dependencies
       run: uv sync --group test --group experimental
 

--- a/.github/workflows/python-publish-test.yml
+++ b/.github/workflows/python-publish-test.yml
@@ -30,8 +30,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0.x'
-
+        dotnet-version: '8.0.x'
     - name: Install dependencies
       run: uv pip install setuptools build wheel twine
 

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -30,8 +30,7 @@ jobs:
     - name: Set up .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: '6.0.x'
-
+        dotnet-version: '8.0.x'
     - name: Install dependencies
       run: uv pip install setuptools build wheel twine
       


### PR DESCRIPTION
.NET 6 reached EOL in November 2024. The C# utility targets netstandard2.0 which builds fine with any modern SDK.