### PR TITLE
Add Architecture Decision Records

### DIFF
--- a/adr/001-pythonnet-interop.md
+++ b/adr/001-pythonnet-interop.md
@@ -1,0 +1,19 @@
+# ADR-001: pythonnet for .NET Interop
+
+**Status:** Accepted
+**Date:** 2019 (inherited from mikeio), kept at 2021 split
+
+## Context
+
+MIKE IO 1D reads results from DHI's MIKE 1D engine, which is built on .NET. Res1d originally lived inside mikeio, which used pythonnet for all .NET interop. When mikeio migrated its DFS layer to mikecore (a C/C++ rewrite) to enable Linux support and simplify installation, the 1D code was split into its own package (May 2021). Unlike DFS file formats, MIKE 1D's .NET API surface is large and complex — result data access, cross sections, network topology, filters — making a C rewrite impractical. The .NET dependency is inherent to MIKE 1D.
+
+## Decision
+
+Use pythonnet as the bridge to .NET MIKE 1D libraries. Bundle the required .NET DLLs in `mikeio1d/bin/` (later moved to NuGet retrieval, see ADR-008). Conversion utilities in `dotnet.py` handle type mapping between Python/numpy and .NET (datetime, arrays).
+
+## Consequences
+
+- Access to the full MIKE 1D .NET API from Python
+- Cross-platform support requires .NET Runtime (8.0 on Linux)
+- New Python version support depends on pythonnet releases
+- 64-bit only (checked on import)

--- a/adr/002-pandas-data-backend.md
+++ b/adr/002-pandas-data-backend.md
@@ -1,0 +1,24 @@
+# ADR-002: pandas DataFrames as Primary Data Container
+
+**Status:** Accepted
+**Date:** 2019 (inherited from mikeio)
+
+## Context
+
+MIKE IO 1D needs an in-memory representation for result data. mikeio uses numpy-backed Dataset/DataArray because DFS data is multi-dimensional and spatial. MIKE 1D results are fundamentally different — tabular time series for nodes, reaches, and catchments with no spatial dimensions.
+
+## Decision
+
+Use pandas DataFrames with DatetimeIndex as the primary data container.
+
+## Alternatives Considered
+
+- **numpy arrays (like mikeio)**: Less natural for tabular time series; users would need to track metadata separately.
+- **Custom Dataset/DataArray**: Unnecessary complexity when pandas already fits the data shape.
+
+## Consequences
+
+- Natural fit for 1D time series data (one column per quantity/location)
+- Familiar API for engineers already using pandas
+- Leverages pandas' time handling, grouping, and aggregation
+- Easy integration with plotting and analysis tools

--- a/adr/003-factory-pattern-open.md
+++ b/adr/003-factory-pattern-open.md
@@ -1,0 +1,23 @@
+# ADR-003: Factory Pattern for File Opening
+
+**Status:** Accepted
+**Date:** 2021
+
+## Context
+
+MIKE 1D files come in many formats: .res1d, .res, .resx, .out (EPANET/SWMM), and .xns11 (cross sections). Users shouldn't need to know which class to instantiate.
+
+## Decision
+
+Provide `mikeio1d.open()` as a single entry point that inspects the file extension and returns the appropriate handler (Res1D or Xns11). Mirrors mikeio's `mikeio.open()`.
+
+## Alternatives Considered
+
+- **Require users to pick the class**: Error-prone; file extensions alone don't always make the distinction obvious.
+- **Single class for all formats**: Would lead to a monolithic class with many conditional branches.
+
+## Consequences
+
+- Simple, discoverable API: `mikeio1d.open("results.res1d")`
+- File type detection is centralized
+- New file types can be added without changing user code

--- a/adr/004-header-only-loading.md
+++ b/adr/004-header-only-loading.md
@@ -1,0 +1,26 @@
+# ADR-004: Header-Only Loading by Default
+
+**Status:** Accepted
+**Date:** 2021 (option), 2024 (default)
+
+## Context
+
+MIKE 1D result files can contain millions of time steps across thousands of network elements. Loading all data eagerly wastes memory and time, especially when users only need a subset of the results.
+
+## Decision
+
+Load only file headers by default. Dynamic results are loaded on demand when `.read()` is called. Filtering by time, quantity, or location can be applied at open time to further limit what is loaded.
+
+Header-only loading was introduced as an option in 2021. In 2024, it became the default behavior, complementing the fluent result network API (ADR-005) which lets users browse metadata and selectively read data.
+
+## Alternatives Considered
+
+- **Eager loading**: Simple but impractical for large files.
+- **Explicit filter-only loading**: Requires users to know upfront what they need; less exploratory.
+
+## Consequences
+
+- Fast file opening regardless of file size
+- Users can explore available quantities and locations without loading data
+- Data loaded only when explicitly requested via `.read()`
+- Filtering at open time enables efficient bulk reads of specific subsets

--- a/adr/005-fluent-result-network-api.md
+++ b/adr/005-fluent-result-network-api.md
@@ -1,0 +1,34 @@
+# ADR-005: Fluent Result Network API with Auto-Completion
+
+**Status:** Accepted
+**Date:** 2023
+
+## Context
+
+Early versions required users to construct query objects manually to access results. This was cumbersome and not discoverable — users had to know the exact quantity names, location IDs, and chainages upfront.
+
+## Decision
+
+Introduce a hierarchical fluent API with IDE auto-completion:
+
+```python
+res = mikeio1d.open("results.res1d")
+res.nodes['node_id'].WaterLevel.read()
+res.reaches['reach_id'][chainage].Discharge.read()
+```
+
+Dynamic attribute generation provides auto-completion for location IDs and quantity names. The access pattern follows: ResultNetwork → ResultNodes/ResultReaches/ResultCatchments → individual location → quantities.
+
+<!-- TODO: @Ryan — add context on design inspiration and how this evolved -->
+
+## Alternatives Considered
+
+- **Keep query-based access only**: Less discoverable; no auto-completion support.
+- **String-based indexing**: Would work but loses the benefit of IDE auto-completion for quantity names.
+
+## Consequences
+
+- Discoverable API that works with IDE and Jupyter tab completion
+- Users can explore available data interactively
+- Works naturally with header-only loading (ADR-004) — browse metadata, then read
+- Largest subsystem in the codebase (~10+ modules in `result_network/`)

--- a/adr/006-derived-quantities.md
+++ b/adr/006-derived-quantities.md
@@ -1,0 +1,26 @@
+# ADR-006: Derived Quantities System
+
+**Status:** Accepted
+**Date:** 2023
+
+## Context
+
+Users frequently need quantities that are not stored directly in result files but can be computed from stored quantities — for example, water depth (from water level and bottom level) or flooding extent.
+
+<!-- TODO: @Ryan — add context on motivation and design choices -->
+
+## Decision
+
+Provide an extensible `DerivedQuantity` base class. Default derived quantities (water depth, flooding, filling, Manning Q-Q, reach absolute discharge, water level above critical) are auto-registered per Res1D instance. Users can add custom derived quantities by subclassing `DerivedQuantity`.
+
+## Alternatives Considered
+
+- **Post-processing only**: Users compute derived values themselves after reading base quantities; error-prone and repetitive.
+- **Pre-computed storage**: Store all derived quantities in result files; increases file size and limits flexibility.
+
+## Consequences
+
+- Common derived quantities available out of the box
+- Computed on demand from base quantities
+- Extensible — users can define and register custom quantities
+- Integrates with the fluent API (ADR-005) — derived quantities appear alongside stored ones

--- a/adr/007-geodataframe-converters.md
+++ b/adr/007-geodataframe-converters.md
@@ -1,0 +1,26 @@
+# ADR-007: GeoDataFrame Converter Pattern
+
+**Status:** Accepted
+**Date:** 2023 (initial), 2024 (refactored)
+
+## Context
+
+Users need to visualize and analyze network results spatially. geopandas is the standard for geospatial tabular data in Python but is a heavy dependency that not all users need.
+
+<!-- TODO: @Ryan — add context on the refactoring from monolithic to separate converters -->
+
+## Decision
+
+Provide separate converter classes per location type: nodes (points), reaches (lines), and catchments (polygons). geopandas is an optional dependency with guarded imports — the package works without it.
+
+## Alternatives Considered
+
+- **Single converter class**: Simpler initially but mixes different geometry types (points, lines, polygons) in one class.
+- **Built-in geopandas dependency**: Would force installation of GDAL/geopandas for all users.
+
+## Consequences
+
+- Clean separation by geometry type (points, lines, polygons)
+- geopandas users get spatial analysis capabilities
+- Core functionality works without geopandas installed
+- Each converter handles the specific geometry and metadata of its location type

--- a/adr/008-nuget-build-system.md
+++ b/adr/008-nuget-build-system.md
@@ -1,0 +1,25 @@
+# ADR-008: NuGet-Based Build System
+
+**Status:** Accepted
+**Date:** 2022
+
+## Context
+
+.NET DLLs were committed to the repository from the initial commit. NuGet packages are the single source of truth for these binaries — vendoring copies in git created a redundant, hard-to-maintain mirror.
+
+## Decision
+
+Remove .NET DLLs from source control. Retrieve them via NuGet at build time using a hatch build hook. The build process also compiles a C# utility library (`DHI.Mike1D.MikeIO`) that provides helper functionality bridging Python and .NET.
+
+## Alternatives Considered
+
+- **Keep DLLs in repo**: Simple but duplicates the source of truth; repository bloat; version updates require manual file replacement.
+- **System MIKE installation only**: Would complicate installation; not all users have MIKE installed.
+
+## Consequences
+
+- NuGet packages are the single source of truth for .NET binaries
+- Cleaner repository without binary files in git history
+- Version updates are a NuGet reference change, not a file swap
+- Build requires network access to retrieve NuGet packages
+- Supports both bundled binaries and system MIKE installations via `MIKE_INSTALL_PATH`


### PR DESCRIPTION
## Summary

Retrofit 8 ADRs documenting key design choices, following the [same format used in mikeio](https://github.com/DHI/mikeio/tree/main/adr).

- **001–002**: Inherited decisions from mikeio (pythonnet, pandas) with context on why they were kept at the 2021 split
- **003–004**: Core patterns (factory open, header-only loading)
- **005–007**: Post-split architecture (fluent API, derived quantities, geodataframe converters) — include TODOs for @gedaskir to add context
- **008**: NuGet build system