### PR TITLE
Disallow modifying resistance via raw setter for non-DISTRIBUTED modes

### DIFF
--- a/mikeio1d/cross_sections/cross_section.py
+++ b/mikeio1d/cross_sections/cross_section.py
@@ -549,8 +549,7 @@ class CrossSection:
             if column_name not in df.columns:
                 raise ValueError(f"Column '{column_name}' is missing from the provided DataFrame.")
 
-        if self.resistance_distribution != ResistanceDistribution.DISTRIBUTED:
-            self._check_resistance_not_modified(df, raw_current)
+        self._update_resistance_distribution_from_raw(df, raw_current)
 
         base_xs = self._m1d_cross_section.BaseCrossSection
         base_xs.Points.Clear()
@@ -559,6 +558,9 @@ class CrossSection:
             point = CrossSectionPoint(x, z)
             point.DistributedResistance = resistance
             base_xs.Points.Add(point)
+
+        if self.resistance_distribution == ResistanceDistribution.UNIFORM:
+            base_xs.FlowResistance.ResistanceValue = float(df.resistance.iloc[0])
 
         markers_seen = set()
         for i, point in enumerate(base_xs.Points):
@@ -575,30 +577,39 @@ class CrossSection:
 
         self.recompute_processed()
 
-    def _check_resistance_not_modified(self, df: pd.DataFrame, raw_current: pd.DataFrame):
-        """Raise ValueError if resistance values were modified for non-DISTRIBUTED modes.
+    def _update_resistance_distribution_from_raw(
+        self, df: pd.DataFrame, raw_current: pd.DataFrame
+    ):
+        """Update resistance distribution type if resistance values were modified in the raw setter.
 
-        For UNIFORM, ZONES, CONSTANT, and EXPONENT_VARYING distributions, resistance
-        is controlled by FlowResistance properties on the cross section, not by per-point
-        values. The per-point DistributedResistance values are derived and overwritten
-        during processing. Modifying them via the raw setter would be silently lost.
+        If resistance values are unchanged, no distribution change is made.
+        If all new resistance values are the same, distribution is set to UNIFORM.
+        If resistance values vary, distribution is set to DISTRIBUTED with a warning
+        if it was previously a different type.
         """
+        resistance_changed = self._resistance_values_changed(df, raw_current)
+        if not resistance_changed:
+            return
+
+        unique_resistances = df.resistance.nunique()
+        if unique_resistances <= 1:
+            self.resistance_distribution = ResistanceDistribution.UNIFORM
+        else:
+            prev = self.resistance_distribution
+            if prev != ResistanceDistribution.DISTRIBUTED:
+                warn(
+                    f"Resistance distribution changed from {prev.name} to DISTRIBUTED "
+                    f"because non-uniform resistance values were set via the raw setter."
+                )
+            self.resistance_distribution = ResistanceDistribution.DISTRIBUTED
+
+    def _resistance_values_changed(
+        self, df: pd.DataFrame, raw_current: pd.DataFrame
+    ) -> bool:
+        """Check whether resistance values differ between the new and current raw DataFrames."""
         if len(df) != len(raw_current):
-            return
-
-        if np.allclose(df.resistance.values, raw_current.resistance.values):
-            return
-
-        distribution = self.resistance_distribution
-        raise ValueError(
-            f"Cannot modify resistance values through the raw setter when "
-            f"resistance_distribution is {distribution.name}. "
-            f"For UNIFORM, set the resistance value via "
-            f"the FlowResistance object on the underlying .NET cross section. "
-            f"For ZONES, use the resistance_left_high_flow, resistance_low_flow, "
-            f"and resistance_right_high_flow properties. "
-            f"For per-point control, set resistance_distribution to DISTRIBUTED first."
-        )
+            return True
+        return not np.array_equal(df.resistance.values, raw_current.resistance.values)
 
     def _update_marker(self, marker: int | Marker, point_index: int):
         """Update the marker of the specified point_index."""

--- a/mikeio1d/cross_sections/cross_section.py
+++ b/mikeio1d/cross_sections/cross_section.py
@@ -553,11 +553,15 @@ class CrossSection:
         base_xs.Points.Clear()
 
         unique_resistances = df.resistance.nunique()
-        if unique_resistances == 1:
-            self.resistance_distribution == ResistanceDistribution.UNIFORM
+        if self.resistance_distribution == ResistanceDistribution.ZONES and unique_resistances <= 3:
+            self._set_zone_resistances_from_raw(df)
+        elif unique_resistances == 1:
+            self.resistance_distribution = ResistanceDistribution.UNIFORM
             base_xs.FlowResistance.ResistanceValue = float(df.resistance.iloc[0])
-
-        if unique_resistances > 3:
+        elif unique_resistances <= 3:
+            self.resistance_distribution = ResistanceDistribution.ZONES
+            self._set_zone_resistances_from_raw(df)
+        else:
             self.resistance_distribution = ResistanceDistribution.DISTRIBUTED
 
         for x, z, resistance in zip(df.x, df.z, df.resistance):
@@ -579,6 +583,28 @@ class CrossSection:
                 self._update_marker(marker, i)
 
         self.recompute_processed()
+
+    def _set_zone_resistances_from_raw(self, df: pd.DataFrame):
+        """Update zone resistance properties from raw DataFrame resistance values."""
+        fr = self._m1d_cross_section.BaseCrossSection.FlowResistance
+
+        left_idx = 0
+        right_idx = len(df) - 1
+
+        for i, markers_str in enumerate(df.markers):
+            if not markers_str:
+                continue
+            markers = Marker.list_from_string(markers_str)
+            if Marker.LEFT_LEVEE_BANK in markers:
+                left_idx = i
+            if Marker.RIGHT_LEVEE_BANK in markers:
+                right_idx = i
+
+        fr.ResistanceLeftHighFlow = float(df.resistance.iloc[left_idx])
+        fr.ResistanceRightHighFlow = float(df.resistance.iloc[right_idx])
+
+        low_flow_idx = left_idx + 1 if right_idx > left_idx else left_idx
+        fr.ResistanceLowFlow = float(df.resistance.iloc[low_flow_idx])
 
     def _update_marker(self, marker: int | Marker, point_index: int):
         """Update the marker of the specified point_index."""

--- a/mikeio1d/cross_sections/cross_section.py
+++ b/mikeio1d/cross_sections/cross_section.py
@@ -549,20 +549,11 @@ class CrossSection:
             if column_name not in df.columns:
                 raise ValueError(f"Column '{column_name}' is missing from the provided DataFrame.")
 
+        if self.resistance_distribution != ResistanceDistribution.DISTRIBUTED:
+            self._check_resistance_not_modified(df, raw_current)
+
         base_xs = self._m1d_cross_section.BaseCrossSection
         base_xs.Points.Clear()
-
-        unique_resistances = df.resistance.nunique()
-        if self.resistance_distribution == ResistanceDistribution.ZONES and unique_resistances <= 3:
-            self._set_zone_resistances_from_raw(df)
-        elif unique_resistances == 1:
-            self.resistance_distribution = ResistanceDistribution.UNIFORM
-            base_xs.FlowResistance.ResistanceValue = float(df.resistance.iloc[0])
-        elif unique_resistances <= 3:
-            self.resistance_distribution = ResistanceDistribution.ZONES
-            self._set_zone_resistances_from_raw(df)
-        else:
-            self.resistance_distribution = ResistanceDistribution.DISTRIBUTED
 
         for x, z, resistance in zip(df.x, df.z, df.resistance):
             point = CrossSectionPoint(x, z)
@@ -584,27 +575,30 @@ class CrossSection:
 
         self.recompute_processed()
 
-    def _set_zone_resistances_from_raw(self, df: pd.DataFrame):
-        """Update zone resistance properties from raw DataFrame resistance values."""
-        fr = self._m1d_cross_section.BaseCrossSection.FlowResistance
+    def _check_resistance_not_modified(self, df: pd.DataFrame, raw_current: pd.DataFrame):
+        """Raise ValueError if resistance values were modified for non-DISTRIBUTED modes.
 
-        left_idx = 0
-        right_idx = len(df) - 1
+        For UNIFORM, ZONES, CONSTANT, and EXPONENT_VARYING distributions, resistance
+        is controlled by FlowResistance properties on the cross section, not by per-point
+        values. The per-point DistributedResistance values are derived and overwritten
+        during processing. Modifying them via the raw setter would be silently lost.
+        """
+        if len(df) != len(raw_current):
+            return
 
-        for i, markers_str in enumerate(df.markers):
-            if not markers_str:
-                continue
-            markers = Marker.list_from_string(markers_str)
-            if Marker.LEFT_LEVEE_BANK in markers:
-                left_idx = i
-            if Marker.RIGHT_LEVEE_BANK in markers:
-                right_idx = i
+        if np.allclose(df.resistance.values, raw_current.resistance.values):
+            return
 
-        fr.ResistanceLeftHighFlow = float(df.resistance.iloc[left_idx])
-        fr.ResistanceRightHighFlow = float(df.resistance.iloc[right_idx])
-
-        low_flow_idx = left_idx + 1 if right_idx > left_idx else left_idx
-        fr.ResistanceLowFlow = float(df.resistance.iloc[low_flow_idx])
+        distribution = self.resistance_distribution
+        raise ValueError(
+            f"Cannot modify resistance values through the raw setter when "
+            f"resistance_distribution is {distribution.name}. "
+            f"For UNIFORM, set the resistance value via "
+            f"the FlowResistance object on the underlying .NET cross section. "
+            f"For ZONES, use the resistance_left_high_flow, resistance_low_flow, "
+            f"and resistance_right_high_flow properties. "
+            f"For per-point control, set resistance_distribution to DISTRIBUTED first."
+        )
 
     def _update_marker(self, marker: int | Marker, point_index: int):
         """Update the marker of the specified point_index."""

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -406,16 +406,36 @@ class TestCrossSectionUnits:
         assert cs_dummy.raw.markers.iloc[0] == ""
         assert cs_dummy.raw.markers.iloc[1] == str(Marker.LEFT_LEVEE_BANK.value)
 
-    def test_raw_set_resistance_uniform(self, cs_dummy):
-        """Test that modifying uniform resistance via raw setter persists correctly."""
-        factor = 10
+    def test_raw_set_resistance_error_uniform(self, cs_dummy):
+        """Test that modifying resistance via raw setter raises error for UNIFORM distribution."""
+        assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
         df = cs_dummy.raw
-        original_resistance = df.resistance.iloc[0]
-        df.resistance *= factor
+        df.resistance *= 10
+        with pytest.raises(ValueError, match="Cannot modify resistance"):
+            cs_dummy.raw = df
+
+    def test_raw_set_resistance_error_zones(self, xns_basic):
+        """Test that modifying resistance via raw setter raises error for ZONES distribution."""
+        zones_css = [
+            cs for cs in xns_basic.values()
+            if cs.resistance_distribution == ResistanceDistribution.ZONES
+        ]
+        assert len(zones_css) > 0, "No ZONES cross sections found in testdata"
+        cs = zones_css[0]
+        df = cs.raw
+        df.resistance *= 10
+        with pytest.raises(ValueError, match="Cannot modify resistance"):
+            cs.raw = df
+
+    def test_raw_set_resistance_unchanged_uniform(self, cs_dummy):
+        """Test that setting raw with unchanged resistance works for UNIFORM distribution."""
+        df = cs_dummy.raw
+        original_resistance = df.resistance.copy()
+        df.z += 100
         cs_dummy.raw = df
         result = cs_dummy.raw
-        expected_resistance = original_resistance * factor
-        np.testing.assert_allclose(result.resistance.values, expected_resistance)
+        np.testing.assert_allclose(result.resistance.values, original_resistance.values)
+        np.testing.assert_allclose(result.z.values, df.z.values)
 
     def test_raw_set_resistance_distributed(self, xz_data):
         """Test that modifying distributed resistance via raw setter persists correctly."""
@@ -423,110 +443,26 @@ class TestCrossSectionUnits:
         cs = CrossSection.from_xz(
             x=x, z=z, location_id="loc1", chainage=100, topo_id="topo1"
         )
+        cs.resistance_distribution = ResistanceDistribution.DISTRIBUTED
         df = cs.raw
         df.resistance = np.arange(1, len(df) + 1, dtype=float)
         cs.raw = df
         result = cs.raw
         np.testing.assert_array_almost_equal(result.resistance.values, df.resistance.values)
 
-    def test_raw_set_resistance_distribution_type_uniform(self, cs_dummy):
-        """Test that the raw setter correctly sets resistance_distribution to UNIFORM."""
-        cs_dummy.resistance_distribution = ResistanceDistribution.DISTRIBUTED
+    def test_raw_set_preserves_distribution_type(self, cs_dummy):
+        """Test that the raw setter preserves the resistance distribution type."""
+        cs_dummy.resistance_distribution = ResistanceDistribution.UNIFORM
         df = cs_dummy.raw
-        df.resistance = 42.0
         cs_dummy.raw = df
         assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
 
-    def test_raw_set_resistance_file_roundtrip(self, tmp_path, xns_basic):
-        """Test that modifying resistance via raw setter persists to file correctly."""
-        factor = 10
-        cs = list(xns_basic.values())[0]
-        original_distribution = cs.resistance_distribution
-
-        df = cs.raw
-        original_resistance = df.resistance.copy()
-        df.resistance *= factor
-        cs.raw = df
-
-        modified_file = tmp_path / "modified.xns11"
-        xns_basic.write(str(modified_file))
-
-        xns_result = Xns11(str(modified_file))
-        result_cs = list(xns_result.values())[0]
-        result_df = result_cs.raw
-        np.testing.assert_allclose(
-            result_df.resistance.values, (original_resistance * factor).values
-        )
-
-    def test_raw_set_resistance_zones_roundtrip(self, tmp_path, xns_basic):
-        """Test that modifying resistance via raw setter works for ZONES distribution."""
-        factor = 10
-        zones_css = [
-            cs for cs in xns_basic.values()
-            if cs.resistance_distribution == ResistanceDistribution.ZONES
-        ]
-        assert len(zones_css) > 0, "No ZONES cross sections found in testdata"
-        cs = zones_css[0]
-        assert cs.resistance_distribution == ResistanceDistribution.ZONES
-
-        df = cs.raw
-        original_resistance = df.resistance.copy()
-        assert original_resistance.sum() > 0, "Original resistance should be non-zero"
-        df.resistance *= factor
-        cs.raw = df
-
-        # Verify in memory
-        result = cs.raw
-        np.testing.assert_allclose(
-            result.resistance.values, (original_resistance * factor).values
-        )
-
-    def test_raw_set_resistance_zones_file_roundtrip(self, tmp_path, xns_basic):
-        """Test that modifying resistance for ZONES distribution persists to file."""
-        factor = 10
-        zones_css = [
-            cs for cs in xns_basic.values()
-            if cs.resistance_distribution == ResistanceDistribution.ZONES
-        ]
-        assert len(zones_css) > 0
-        cs = zones_css[0]
-
-        df = cs.raw
-        original_resistance = df.resistance.copy()
-        df.resistance *= factor
-        cs.raw = df
-
-        modified_file = tmp_path / "modified.xns11"
-        xns_basic.write(str(modified_file))
-
-        xns_result = Xns11(str(modified_file))
-        zones_result = [
-            cs for cs in xns_result.values()
-            if cs.resistance_distribution == ResistanceDistribution.ZONES
-        ]
-        result_df = zones_result[0].raw
-        np.testing.assert_allclose(
-            result_df.resistance.values, (original_resistance * factor).values
-        )
-
-    def test_raw_set_resistance_xns11_file_roundtrip(self, tmp_path, xns_basic):
-        """Test resistance modification roundtrip using actual xns11 testdata."""
-        factor = 10
-        cs = list(xns_basic.values())[0]
-        df = cs.raw
-        original_resistance = df.resistance.copy()
-        df.resistance *= factor
-        cs.raw = df
-
-        modified_file = tmp_path / "modified.xns11"
-        xns_basic.write(str(modified_file))
-
-        xns_result = Xns11(str(modified_file))
-        result_cs = list(xns_result.values())[0]
-        result_df = result_cs.raw
-        np.testing.assert_allclose(
-            result_df.resistance.values, (original_resistance * factor).values
-        )
+    def test_raw_set_geometry_change_allows_resistance_column(self, cs_dummy):
+        """Test that adding/removing points doesn't error on resistance even for UNIFORM."""
+        assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
+        df = cs_dummy.raw
+        df = df.iloc[2:-2].reset_index(drop=True)
+        cs_dummy.raw = df
 
     def test_markers_get(self, cs_dummy):
         markers = cs_dummy.markers

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -406,16 +406,16 @@ class TestCrossSectionUnits:
         assert cs_dummy.raw.markers.iloc[0] == ""
         assert cs_dummy.raw.markers.iloc[1] == str(Marker.LEFT_LEVEE_BANK.value)
 
-    def test_raw_set_resistance_error_uniform(self, cs_dummy):
-        """Test that modifying resistance via raw setter raises error for UNIFORM distribution."""
+    def test_raw_set_resistance_uniform_cast(self, cs_dummy):
+        """Test that setting uniform resistance via raw setter casts to UNIFORM."""
         assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
         df = cs_dummy.raw
-        df.resistance *= 10
-        with pytest.raises(ValueError, match="Cannot modify resistance"):
-            cs_dummy.raw = df
+        df.resistance = 50.0
+        cs_dummy.raw = df
+        assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
 
-    def test_raw_set_resistance_error_zones(self, xns_basic):
-        """Test that modifying resistance via raw setter raises error for ZONES distribution."""
+    def test_raw_set_resistance_warns_zones_to_distributed(self, xns_basic):
+        """Test that modifying resistance on ZONES cross section warns and casts to DISTRIBUTED."""
         zones_css = [
             cs for cs in xns_basic.values()
             if cs.resistance_distribution == ResistanceDistribution.ZONES
@@ -423,17 +423,27 @@ class TestCrossSectionUnits:
         assert len(zones_css) > 0, "No ZONES cross sections found in testdata"
         cs = zones_css[0]
         df = cs.raw
-        df.resistance *= 10
-        with pytest.raises(ValueError, match="Cannot modify resistance"):
+        df.resistance = np.arange(1, len(df) + 1, dtype=float)
+        with pytest.warns(match="Resistance distribution changed from ZONES to DISTRIBUTED"):
             cs.raw = df
+        assert cs.resistance_distribution == ResistanceDistribution.DISTRIBUTED
+
+    def test_raw_set_resistance_uniform_value_persists(self, cs_dummy):
+        """Test that setting uniform resistance via raw setter persists the value."""
+        df = cs_dummy.raw
+        df.resistance = 42.0
+        cs_dummy.raw = df
+        result = cs_dummy.raw
+        np.testing.assert_allclose(result.resistance.values, 42.0)
 
     def test_raw_set_resistance_unchanged_uniform(self, cs_dummy):
-        """Test that setting raw with unchanged resistance works for UNIFORM distribution."""
+        """Test that setting raw with unchanged resistance preserves UNIFORM distribution."""
         df = cs_dummy.raw
         original_resistance = df.resistance.copy()
         df.z += 100
         cs_dummy.raw = df
         result = cs_dummy.raw
+        assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
         np.testing.assert_allclose(result.resistance.values, original_resistance.values)
         np.testing.assert_allclose(result.z.values, df.z.values)
 
@@ -451,11 +461,20 @@ class TestCrossSectionUnits:
         np.testing.assert_array_almost_equal(result.resistance.values, df.resistance.values)
 
     def test_raw_set_preserves_distribution_type(self, cs_dummy):
-        """Test that the raw setter preserves the resistance distribution type."""
+        """Test that the raw setter preserves the resistance distribution type when unchanged."""
         cs_dummy.resistance_distribution = ResistanceDistribution.UNIFORM
         df = cs_dummy.raw
         cs_dummy.raw = df
         assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
+
+    def test_raw_set_warns_uniform_to_distributed(self, cs_dummy):
+        """Test that non-uniform resistance on a UNIFORM cross section warns and casts."""
+        assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
+        df = cs_dummy.raw
+        df.resistance = np.arange(1, len(df) + 1, dtype=float)
+        with pytest.warns(match="Resistance distribution changed from UNIFORM to DISTRIBUTED"):
+            cs_dummy.raw = df
+        assert cs_dummy.resistance_distribution == ResistanceDistribution.DISTRIBUTED
 
     def test_raw_set_geometry_change_allows_resistance_column(self, cs_dummy):
         """Test that adding/removing points doesn't error on resistance even for UNIFORM."""

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -406,6 +406,128 @@ class TestCrossSectionUnits:
         assert cs_dummy.raw.markers.iloc[0] == ""
         assert cs_dummy.raw.markers.iloc[1] == str(Marker.LEFT_LEVEE_BANK.value)
 
+    def test_raw_set_resistance_uniform(self, cs_dummy):
+        """Test that modifying uniform resistance via raw setter persists correctly."""
+        factor = 10
+        df = cs_dummy.raw
+        original_resistance = df.resistance.iloc[0]
+        df.resistance *= factor
+        cs_dummy.raw = df
+        result = cs_dummy.raw
+        expected_resistance = original_resistance * factor
+        np.testing.assert_allclose(result.resistance.values, expected_resistance)
+
+    def test_raw_set_resistance_distributed(self, xz_data):
+        """Test that modifying distributed resistance via raw setter persists correctly."""
+        x, z = xz_data
+        cs = CrossSection.from_xz(
+            x=x, z=z, location_id="loc1", chainage=100, topo_id="topo1"
+        )
+        df = cs.raw
+        df.resistance = np.arange(1, len(df) + 1, dtype=float)
+        cs.raw = df
+        result = cs.raw
+        np.testing.assert_array_almost_equal(result.resistance.values, df.resistance.values)
+
+    def test_raw_set_resistance_distribution_type_uniform(self, cs_dummy):
+        """Test that the raw setter correctly sets resistance_distribution to UNIFORM."""
+        cs_dummy.resistance_distribution = ResistanceDistribution.DISTRIBUTED
+        df = cs_dummy.raw
+        df.resistance = 42.0
+        cs_dummy.raw = df
+        assert cs_dummy.resistance_distribution == ResistanceDistribution.UNIFORM
+
+    def test_raw_set_resistance_file_roundtrip(self, tmp_path, xns_basic):
+        """Test that modifying resistance via raw setter persists to file correctly."""
+        factor = 10
+        cs = list(xns_basic.values())[0]
+        original_distribution = cs.resistance_distribution
+
+        df = cs.raw
+        original_resistance = df.resistance.copy()
+        df.resistance *= factor
+        cs.raw = df
+
+        modified_file = tmp_path / "modified.xns11"
+        xns_basic.write(str(modified_file))
+
+        xns_result = Xns11(str(modified_file))
+        result_cs = list(xns_result.values())[0]
+        result_df = result_cs.raw
+        np.testing.assert_allclose(
+            result_df.resistance.values, (original_resistance * factor).values
+        )
+
+    def test_raw_set_resistance_zones_roundtrip(self, tmp_path, xns_basic):
+        """Test that modifying resistance via raw setter works for ZONES distribution."""
+        factor = 10
+        zones_css = [
+            cs for cs in xns_basic.values()
+            if cs.resistance_distribution == ResistanceDistribution.ZONES
+        ]
+        assert len(zones_css) > 0, "No ZONES cross sections found in testdata"
+        cs = zones_css[0]
+        assert cs.resistance_distribution == ResistanceDistribution.ZONES
+
+        df = cs.raw
+        original_resistance = df.resistance.copy()
+        assert original_resistance.sum() > 0, "Original resistance should be non-zero"
+        df.resistance *= factor
+        cs.raw = df
+
+        # Verify in memory
+        result = cs.raw
+        np.testing.assert_allclose(
+            result.resistance.values, (original_resistance * factor).values
+        )
+
+    def test_raw_set_resistance_zones_file_roundtrip(self, tmp_path, xns_basic):
+        """Test that modifying resistance for ZONES distribution persists to file."""
+        factor = 10
+        zones_css = [
+            cs for cs in xns_basic.values()
+            if cs.resistance_distribution == ResistanceDistribution.ZONES
+        ]
+        assert len(zones_css) > 0
+        cs = zones_css[0]
+
+        df = cs.raw
+        original_resistance = df.resistance.copy()
+        df.resistance *= factor
+        cs.raw = df
+
+        modified_file = tmp_path / "modified.xns11"
+        xns_basic.write(str(modified_file))
+
+        xns_result = Xns11(str(modified_file))
+        zones_result = [
+            cs for cs in xns_result.values()
+            if cs.resistance_distribution == ResistanceDistribution.ZONES
+        ]
+        result_df = zones_result[0].raw
+        np.testing.assert_allclose(
+            result_df.resistance.values, (original_resistance * factor).values
+        )
+
+    def test_raw_set_resistance_xns11_file_roundtrip(self, tmp_path, xns_basic):
+        """Test resistance modification roundtrip using actual xns11 testdata."""
+        factor = 10
+        cs = list(xns_basic.values())[0]
+        df = cs.raw
+        original_resistance = df.resistance.copy()
+        df.resistance *= factor
+        cs.raw = df
+
+        modified_file = tmp_path / "modified.xns11"
+        xns_basic.write(str(modified_file))
+
+        xns_result = Xns11(str(modified_file))
+        result_cs = list(xns_result.values())[0]
+        result_df = result_cs.raw
+        np.testing.assert_allclose(
+            result_df.resistance.values, (original_resistance * factor).values
+        )
+
     def test_markers_get(self, cs_dummy):
         markers = cs_dummy.markers
         assert isinstance(markers, pd.DataFrame)


### PR DESCRIPTION
## Summary

The `CrossSection.raw` setter previously tried to infer `resistance_distribution` from the number of unique resistance values in the DataFrame. This had two problems:

1. **Bug**: The UNIFORM branch used `==` (comparison) instead of `=` (assignment), so the distribution was never actually changed — though `FlowResistance.ResistanceValue` was still set correctly.
2. **Fragile heuristic**: The `nunique() > 3` threshold for auto-switching to DISTRIBUTED was arbitrary and could misfire for 2–3 unique values.

This PR replaces that heuristic with explicit, predictable casting that only triggers when resistance values actually change.

## New behavior

| Scenario | Action |
|---|---|
| Resistance values unchanged | No distribution change — preserves existing type |
| All same value (nunique ≤ 1) | Cast to **UNIFORM**, persist via `FlowResistance.ResistanceValue` |
| Multiple distinct values (nunique > 1) | Cast to **DISTRIBUTED** + **warning** if previously non-DISTRIBUTED |

Casting is based on exact equality (`np.array_equal`), so only intentional modifications trigger a distribution change.

## How to update resistance in Python

The existing API provides the right way to modify resistance for each distribution type:

**UNIFORM** (via raw setter — still supported):
```python
df = cs.raw
df.resistance = 50
cs.raw = df  # auto-casts to UNIFORM
```

**ZONES** (documented in `xns11_writing_and_modifying` notebook):
```python
cs.resistance_distribution = ResistanceDistribution.ZONES
cs.resistance_left_high_flow = 25
cs.resistance_low_flow = 5
cs.resistance_right_high_flow = 30
```

**DISTRIBUTED** (per-point control via raw setter):
```python
cs.resistance_distribution = ResistanceDistribution.DISTRIBUTED
df = cs.raw
df.resistance = new_values
cs.raw = df
```
Or simply set non-uniform values — the setter will auto-cast to DISTRIBUTED with a warning:
```python
df = cs.raw
df.resistance = [1, 2, 3, 4, 5, 6]  # non-uniform triggers warning + cast
cs.raw = df
```

**Processed data** (direct table control):
```python
df = cs.processed
df.resistance = df.resistance * 2.0
cs.processed = df
```

## Changes

### `cross_section.py`
- Raw setter auto-casts to UNIFORM when all resistance values are the same
- Raw setter auto-casts to DISTRIBUTED (with warning) when resistance values vary and distribution was not already DISTRIBUTED
- Casting only occurs when resistance values actually changed (`np.array_equal`)
- Persists UNIFORM resistance via `FlowResistance.ResistanceValue`
- Fixed the old `==` vs `=` bug

### `test_cross_section.py`
- Tests that uniform resistance casts to UNIFORM and persists the value
- Tests that non-uniform resistance warns and casts to DISTRIBUTED (from UNIFORM and ZONES)
- Tests that unchanged resistance preserves distribution type
- Tests that DISTRIBUTED per-point modification works
- Tests that geometry changes (adding/removing points) are allowed
