### PR TITLE
Bug linux import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ mikeio1d/bin/**/*.dll
 mikeio1d/bin/**/*.pfs
 mikeio1d/bin/**/*.ubg
 mikeio1d/bin/**/*.xml
+mikeio1d/bin/**/*.so
 mikeio1d/bin/**/*so.5
 
 # mikeio1d/util/bin folder

--- a/mikeio1d/__init__.py
+++ b/mikeio1d/__init__.py
@@ -28,7 +28,7 @@ from .mikepath import MikePath
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 # UV may ignore requires-python upper bounds for local installs, potentially causing
 # compatibility issues with dependencies like 'pythonnet'. Adding this warning to help

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = ["mikeio1d"]
 
 [project]
 name = "mikeio1d"
-version = "1.2.0"
+version = "1.2.1"
 description = "A package that uses the DHI MIKE1D .NET libraries to read res1d and xns11 files."
 readme = "README.md"
 requires-python = ">=3.10,<3.14"

--- a/scripts/hatch_build_script.py
+++ b/scripts/hatch_build_script.py
@@ -29,6 +29,7 @@ class BuildHook(BuildHookInterface):
             "mikeio1d/bin/**/*.pfs",
             "mikeio1d/bin/**/*.ubg",
             "mikeio1d/bin/**/*.xml",
+            "mikeio1d/bin/**/*.so",
             "mikeio1d/bin/**/*so.5",
             "mikeio1d/bin/DHI.Mike1D.MikeIO/**/*",
         ]


### PR DESCRIPTION
Version 1.2.0 changed the wheel building logic to fix publishing issues to pypi.

However, the new logic did not include all necessary binaries inside the wheel. That broke `mikeio1d` imports in Linux systems. The issue did not appear in CI since `uv sync` does not install from the wheel.