### PR TITLE
Drop support for Python 3.10 and 3.11

### DIFF
--- a/.github/workflows/full_test.yml
+++ b/.github/workflows/full_test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.14"]
+        python-version: ["3.12", "3.14"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ MIKE IO 1D is a Python package for reading and manipulating MIKE 1D result files
 
 The package is fundamentally a Python wrapper around the [DHI MIKE 1D .NET library](https://docs.mikepoweredbydhi.com/engine_libraries/mike1d/mike1d_api/). The key .NET namespaces are `DHI.Mike1D.ResultDataAccess`, `DHI.Mike1D.Generic`, and `DHI.Mike1D.CrossSectionModule`. The .NET assemblies (version 23.0.3) are downloaded from NuGet at install time and placed in `mikeio1d/bin/`.
 
-**Requirements:** Python 3.10–3.13 (64-bit only), `uv` package manager, .NET 8.0 Runtime (Linux) or VC++ redistributables (Windows).
+**Requirements:** Python 3.12–3.14 (64-bit only), `uv` package manager, .NET 8.0 Runtime (Linux) or VC++ redistributables (Windows).
 
 ## Commands
 
@@ -21,7 +21,7 @@ uv sync --reinstall --group dev --group test --group notebooks --python 3.13
 ```
 
 ```bash
-# Install dev dependencies (use highest supported version, currently 3.13 — pythonnet doesn't support 3.14+)
+# Install dev dependencies (use highest supported version, currently 3.14)
 # Uses --group (PEP 735 dependency-groups), not --extra
 uv sync --group dev --group test --group notebooks --python 3.13
 
@@ -126,4 +126,4 @@ python scripts/install_dependencies.py  # copies DLL to correct location
 
 **pythonnet / Python version issues**
 
-pythonnet does not support Python 3.14+. Use Python 3.10–3.13 (64-bit). Check `pythonnet>=3.0.0` is installed.
+Use Python 3.12–3.14 (64-bit). Check `pythonnet>=3.0.0` is installed.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,17 @@ This project uses [`uv`](https://docs.astral.sh/uv/) as the package manager. If 
    ```bash
    uv sync --extra dev --extra test --extra notebooks --python 3.XX
    ```
-   Replace `XX` with your Python version (3.10 through 3.14 are supported).
+   Replace `XX` with your Python version (3.12 through 3.14 are supported).
 3. **Verify installation** with `uv run pytest`
+
+## Supported Python versions
+
+MIKE IO 1D follows the [Scientific Python SPEC 0](https://scientific-python.org/specs/spec-0000/)
+recommendation for dropping support of older Python versions. In short, support for a Python
+minor version is dropped 3 years after its initial release. When bumping the minimum supported
+Python version, remember to update it in `pyproject.toml` (`requires-python` and the
+`Programming Language :: Python` classifiers), the CI matrix in `.github/workflows/full_test.yml`,
+and the requirements listed in `README.md` and `docs/index.qmd`.
 
 ## Making Contributions
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Most users of MIKE IO 1D will also find [MIKE+Py](https://github.com/DHI/mikeplu
 
 ## Requirements
 * Windows, Linux (experimental)
-* Python x64 3.10 - 3.14
+* Python x64 3.12 - 3.14
 * (Windows) [VC++ redistributables](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) (already installed if you have MIKE)
 * (Linux) [.NET Runtime](https://learn.microsoft.com/en-us/dotnet/core/install/linux) (not installed by default)
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -23,7 +23,7 @@ pip install mikeio1d
 
 ::: {.callout-note collapse="true" title="Requirements"}
 -   Windows, Linux
--   Python x64 3.10 - 3.14
+-   Python x64 3.12 - 3.14
 -   (Windows) [VC++ redistributables](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads%3E) (already installed if you have MIKE)
 -   (Linux) [.NET Runtime](https://learn.microsoft.com/en-us/dotnet/core/install/linux) (not installed by default)
 :::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ name = "mikeio1d"
 version = "1.2.1"
 description = "A package that uses the DHI MIKE1D .NET libraries to read res1d and xns11 files."
 readme = "README.md"
-requires-python = ">=3.10,<3.15"
+requires-python = ">=3.12,<3.15"
 license = { file = "LICENSE" }
 authors = [{ name = "Gediminas Kirsanskas", email = "geki@dhigroup.com" }]
 classifiers = [
@@ -31,8 +31,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",


### PR DESCRIPTION
## Summary

Removes support for Python 3.10 and 3.11 per #238. The new minimum supported version is **Python 3.12** (supported range 3.12–3.14).

## Changes

- **`pyproject.toml`**: bump `requires-python` to `>=3.12,<3.15` and drop the `3.10`/`3.11` classifiers
- **CI** (`.github/workflows/full_test.yml`): update the test matrix to `["3.12", "3.14"]` (lowest-supported + highest)
- **Docs** (`README.md`, `docs/index.qmd`, `CLAUDE.md`): update version references to `3.12–3.14`
- **`CONTRIBUTING.md`**: add a "Supported Python versions" section documenting that the project follows [Scientific Python SPEC 0](https://scientific-python.org/specs/spec-0000/) for dropping older Python versions, with a checklist of where to bump the version

## Notes

- `mikeio1d/__init__.py` reads the support range dynamically from package metadata — no hardcoded versions to change.
- The other workflows (`docs.yml`, `python-publish*.yml`) already pin 3.12, which remains supported.
- `CHANGELOG.md` references are historical and left intact.

Closes #238

🤖 Generated with [Claude Code](https://claude.com/claude-code)