### PR TITLE
Add regression test for reading LTS datetime quantities (#232)

### DIFF
--- a/tests/test_res1d_lts_events.py
+++ b/tests/test_res1d_lts_events.py
@@ -118,6 +118,18 @@ def test_read_node(test_file, quantity, node_id, expected_max):
     assert pytest.approx(actual_max) == expected_max
 
 
+def test_update_time_quantities_with_nonzero_times(test_file):
+    # Regression for #232: LTS event-time columns hold seconds-since-start as float32.
+    # The fixture's times are all 0, so feed realistic non-zero values to ensure the
+    # datetime conversion replaces the float column instead of an in-place (lossy) set.
+    df = pd.DataFrame(
+        np.array([[3.15e9], [1.94e9]], dtype="float32"),
+        columns=["WaterLevelMaximumTime:B858"],
+    )
+    test_file.reader.update_time_quantities(df)
+    assert df["WaterLevelMaximumTime:B858"].dtype == "datetime64[ns]"
+
+
 def test_time_index(test_file):
     assert len(test_file.time_index) == 10
 


### PR DESCRIPTION
## Summary

Adds a regression test guarding issue #232: reading a datetime-valued LTS quantity (e.g. `nodes["B858"].WaterLevelMaximumTime.read()`) raised `LossySetitemError` → `TypeError: Invalid value '[datetime.datetime(...), ...]' for dtype 'float32'`.

## Background

LTS event-time columns are read as `float32` seconds-since-start and converted to datetime in `ResultReader.update_time_quantities`. The v1.2.0 code built a list of python datetimes and assigned it via `df.iloc[:, i] = [...]` — an **in-place** positional set that pandas 3.0 rejects when the target column is `float32`.

The bug was already fixed on `main` (commit `2761f02` switched to label-based `df[colname] = <Series>`, which replaces the column instead of writing in place; `314a311` later pinned the `datetime64[ns]` dtype). It is **not** present in v1.2.0 but **is** fixed in v1.2.1+.

## Why a new test was needed

The bundled LTS fixture (`lts_event_statistics.res1d`) has all-zero event times, so a normal `.read()` never exercised the failing conversion path. This test feeds realistic non-zero `float32` values directly through `update_time_quantities` and asserts the result is `datetime64[ns]`.

Verified both directions:
- Passes on `main`.
- Against the v1.2.0-style in-place assignment, it reproduces the exact #232 error.

Closes #232.

🤖 Generated with [Claude Code](https://claude.com/claude-code)