### PR TITLE
Fix conveyance factor ignoring resistance type (#229)

### DIFF
--- a/mikeio1d/cross_sections/cross_section.py
+++ b/mikeio1d/cross_sections/cross_section.py
@@ -24,8 +24,8 @@ from .enums import ProcessLevelsMethod
 
 from ..various import try_import_shapely
 
-import System
 from DHI.Mike1D.CrossSectionModule import CrossSectionPoint
+from DHI.Mike1D.CrossSectionModule import CrossSectionExtensions
 from DHI.Mike1D.CrossSectionModule import ICrossSection
 from DHI.Mike1D.Generic import ProcessingOption
 from DHI.Mike1D.Generic import ResistanceDistribution as m1d_ResistanceDistribution
@@ -419,62 +419,6 @@ class CrossSection:
         """
         self._m1d_cross_section.BaseCrossSection.CalculateProcessedData()
 
-    def _convert_resistance_to_standard(
-        self, resistance: Tuple[float], radius: Tuple[float]
-    ) -> Tuple[float]:
-        """Convert processed resistance factors to the standard (Manning's M) formulation.
-
-        MIKE 1D stores processed resistance factors in the cross section's own formulation
-        (e.g. Manning's n), but the conveyance factor formula expects Manning's M. This
-        converts the factors so that, for example, Manning's n = 0.02 is treated as its
-        equivalent Manning's M = 50. Formulations that need no conversion (e.g. Manning's M,
-        Chezy, Relative) are returned unchanged. See issue #229.
-
-        This mirrors the .NET engine's own standardization step
-        (XSBase.ConvertModifiedResistanceFactorsIfNecessary), which calls the same
-        FlowResistance.ConvertToStandardResistances method with the processed radii. Reusing
-        the .NET conversion keeps the formulation handling in sync with the engine rather than
-        re-implementing the resistance conversions in Python.
-
-        The .NET signature is:
-
-            bool ConvertToStandardResistances(
-                ResistanceFormulation currentFormulation,
-                out ResistanceFormulation newFormulation,
-                double[] currentResistances,
-                ref double[] newResistances,
-                double[] hydraulicRadii)
-
-        It returns True only when a conversion actually takes place (currently just
-        Manning's n -> Manning's M); otherwise it returns False and leaves ``newResistances``
-        pointing at ``currentResistances``. Via pythonnet, the ``out``/``ref`` parameters are
-        appended to the return value, so the call returns the tuple
-        ``(converted, newFormulation, newResistances)``. We only need ``converted`` and the
-        resulting ``newResistances`` -- the standardized formulation is discarded.
-        """
-        if len(resistance) == 0:
-            return tuple()
-
-        flow_resistance = self._m1d_cross_section.BaseCrossSection.FlowResistance
-        current_formulation = m1d_ResistanceFormulation(int(self.resistance_type))
-        current_resistances = System.Array[System.Double](list(resistance))
-        hydraulic_radii = System.Array[System.Double](list(radius))
-        # ``newResistances`` is a ref parameter, so an array must be passed in; the engine
-        # overwrites it (and rebinds it in the returned tuple) when a conversion happens. The
-        # second argument is the ``out newFormulation`` placeholder -- its input value is
-        # ignored by pythonnet, so we just pass the current formulation again.
-        new_resistances = System.Array[System.Double](len(resistance))
-        converted, _new_formulation, new_resistances = flow_resistance.ConvertToStandardResistances(
-            current_formulation,
-            current_formulation,
-            current_resistances,
-            new_resistances,
-            hydraulic_radii,
-        )
-        if not converted:
-            return tuple(resistance)
-        return tuple(new_resistances)
-
     def _calculate_conveyance_factor(
         self, resistance: Tuple[float], flow_area: Tuple[float], radius: Tuple[float]
     ) -> Tuple[float]:
@@ -486,15 +430,63 @@ class CrossSection:
         the MIKE+ documentation:
         https://doc.mikepoweredbydhi.help/webhelp/2024/MIKEPlus/MIKEPlus/RiverNetwork_HydrModel/Processed_Data.htm#XREF_52990_Processed_Data:~:text=Note%3A%20The%20conveyance,from%20the%20simulations.
 
-        The resistance factors are first converted to the standard Manning's M formulation
-        (see _convert_resistance_to_standard) so that the conveyance reflects the cross section's
-        resistance type (see issue #229). The simplified resistance * area * radius**(2/3) form is
-        kept rather than calling the engine's CalculateSpecificConveyance directly: the latter
-        raises for Relative resistance (and other non-standard formulations), whereas the cross
-        section editor's processed-data table must still display a monotonicity indicator for them.
+        The MIKE 1D engine's CalculateSpecificConveyance is tried first so that the conveyance stays
+        in sync with the engine and automatically benefits from any future support for additional
+        resistance formulations. It currently raises for formulations it does not handle (e.g.
+        Relative, Manning's n); in that case we fall back to a Python implementation that mirrors the
+        MIKE+ cross section editor's processed-data table (see issue #229).
         """
-        resistance = self._convert_resistance_to_standard(resistance, radius)
-        return tuple(r * A * R ** (2.0 / 3) for r, A, R in zip(resistance, flow_area, radius))
+        conveyance = self._calculate_conveyance_factor_dotnet(resistance, flow_area, radius)
+        if conveyance is not None:
+            return conveyance
+        return self._calculate_conveyance_factor_python(resistance, flow_area, radius)
+
+    def _calculate_conveyance_factor_dotnet(
+        self, resistance: Tuple[float], flow_area: Tuple[float], radius: Tuple[float]
+    ) -> Tuple[float] | None:
+        """Calculate the conveyance factor using the MIKE 1D engine.
+
+        CalculateSpecificConveyance returns the specific conveyance (conveyance per unit area), so
+        each value is multiplied by the flow area to obtain the conveyance factor. The slope is left
+        at its default (-1), which selects the engine's slope-independent "design" conveyance for the
+        formulations that would otherwise need one (Colebrook-White, Hazen-Williams), and a null
+        HDParameterData lets the engine use its defaults.
+
+        Returns None if the engine does not support the cross section's resistance formulation (it
+        raises in that case), signalling the caller to fall back to the Python implementation.
+        """
+        formulation = m1d_ResistanceFormulation(int(self.resistance_type))
+        try:
+            return tuple(
+                A
+                * CrossSectionExtensions.CalculateSpecificConveyance(formulation, r, R, None, -1.0)
+                for r, A, R in zip(resistance, flow_area, radius)
+            )
+        except Exception:
+            # The engine raises for formulations it does not handle; fall back to Python.
+            return None
+
+    def _calculate_conveyance_factor_python(
+        self, resistance: Tuple[float], flow_area: Tuple[float], radius: Tuple[float]
+    ) -> Tuple[float]:
+        """Calculate the conveyance factor in Python, mirroring the MIKE+ cross section editor.
+
+        The formula depends on the cross section's resistance type (see issue #229). Formulations the
+        editor does not display a value for (Colebrook-White, Hazen-Williams, Manning's M relative)
+        return the editor's -999 sentinel.
+        """
+        rt = self.resistance_type
+        if rt in (ResistanceType.MANNINGS_M, ResistanceType.RELATIVE):
+            return tuple(A * R ** (2.0 / 3) * r for r, A, R in zip(resistance, flow_area, radius))
+        elif rt == ResistanceType.MANNINGS_N:
+            return tuple(
+                A * R ** (2.0 / 3) / r if r > 1e-6 else -1.0
+                for r, A, R in zip(resistance, flow_area, radius)
+            )
+        elif rt in (ResistanceType.CHEZY, ResistanceType.DARCY_WEISBACH):
+            return tuple(A * R**0.5 * r for r, A, R in zip(resistance, flow_area, radius))
+        else:
+            return tuple(-999.0 for _ in resistance)
 
     @property
     def processed(self) -> pd.DataFrame:

--- a/mikeio1d/cross_sections/cross_section.py
+++ b/mikeio1d/cross_sections/cross_section.py
@@ -435,21 +435,45 @@ class CrossSection:
         FlowResistance.ConvertToStandardResistances method with the processed radii. Reusing
         the .NET conversion keeps the formulation handling in sync with the engine rather than
         re-implementing the resistance conversions in Python.
+
+        The .NET signature is:
+
+            bool ConvertToStandardResistances(
+                ResistanceFormulation currentFormulation,
+                out ResistanceFormulation newFormulation,
+                double[] currentResistances,
+                ref double[] newResistances,
+                double[] hydraulicRadii)
+
+        It returns True only when a conversion actually takes place (currently just
+        Manning's n -> Manning's M); otherwise it returns False and leaves ``newResistances``
+        pointing at ``currentResistances``. Via pythonnet, the ``out``/``ref`` parameters are
+        appended to the return value, so the call returns the tuple
+        ``(converted, newFormulation, newResistances)``. We only need ``converted`` and the
+        resulting ``newResistances`` -- the standardized formulation is discarded.
         """
         if len(resistance) == 0:
             return tuple()
 
-        fr = self._m1d_cross_section.BaseCrossSection.FlowResistance
-        from_formulation = m1d_ResistanceFormulation(int(self.resistance_type))
-        resistance_array = System.Array[System.Double](list(resistance))
-        radius_array = System.Array[System.Double](list(radius))
-        standard_resistance = System.Array[System.Double](len(resistance))
-        converted, _, standard_resistance = fr.ConvertToStandardResistances(
-            from_formulation, from_formulation, resistance_array, standard_resistance, radius_array
+        flow_resistance = self._m1d_cross_section.BaseCrossSection.FlowResistance
+        current_formulation = m1d_ResistanceFormulation(int(self.resistance_type))
+        current_resistances = System.Array[System.Double](list(resistance))
+        hydraulic_radii = System.Array[System.Double](list(radius))
+        # ``newResistances`` is a ref parameter, so an array must be passed in; the engine
+        # overwrites it (and rebinds it in the returned tuple) when a conversion happens. The
+        # second argument is the ``out newFormulation`` placeholder -- its input value is
+        # ignored by pythonnet, so we just pass the current formulation again.
+        new_resistances = System.Array[System.Double](len(resistance))
+        converted, _new_formulation, new_resistances = flow_resistance.ConvertToStandardResistances(
+            current_formulation,
+            current_formulation,
+            current_resistances,
+            new_resistances,
+            hydraulic_radii,
         )
         if not converted:
             return tuple(resistance)
-        return tuple(standard_resistance)
+        return tuple(new_resistances)
 
     def _calculate_conveyance_factor(
         self, resistance: Tuple[float], flow_area: Tuple[float], radius: Tuple[float]
@@ -617,9 +641,7 @@ class CrossSection:
 
         self.recompute_processed()
 
-    def _update_resistance_distribution_from_raw(
-        self, df: pd.DataFrame, raw_current: pd.DataFrame
-    ):
+    def _update_resistance_distribution_from_raw(self, df: pd.DataFrame, raw_current: pd.DataFrame):
         """Update resistance distribution type if resistance values were modified in the raw setter.
 
         If resistance values are unchanged, no distribution change is made.
@@ -643,9 +665,7 @@ class CrossSection:
                 )
             self.resistance_distribution = ResistanceDistribution.DISTRIBUTED
 
-    def _resistance_values_changed(
-        self, df: pd.DataFrame, raw_current: pd.DataFrame
-    ) -> bool:
+    def _resistance_values_changed(self, df: pd.DataFrame, raw_current: pd.DataFrame) -> bool:
         """Check whether resistance values differ between the new and current raw DataFrames."""
         if len(df) != len(raw_current):
             return True

--- a/tests/test_cross_section.py
+++ b/tests/test_cross_section.py
@@ -54,6 +54,39 @@ def cs_sample(xns_basic) -> List[CrossSection]:
     return x
 
 
+# Closed-form conveyance factor per resistance type, expressed from the processed
+# resistance (r), flow area (A) and hydraulic radius (R). These mirror the formula
+# used by the MIKE+ cross section editor's processed-data table (issue #229) and are
+# written out explicitly here so the test does not depend on the implementation.
+CONVEYANCE_FORMULAS = {
+    ResistanceType.RELATIVE: lambda r, A, R: A * R ** (2.0 / 3) * r,
+    ResistanceType.MANNINGS_M: lambda r, A, R: A * R ** (2.0 / 3) * r,
+    ResistanceType.MANNINGS_N: lambda r, A, R: A * R ** (2.0 / 3) / r,
+    ResistanceType.CHEZY: lambda r, A, R: A * R**0.5 * r,
+    ResistanceType.DARCY_WEISBACH: lambda r, A, R: A * R**0.5 * r,
+}
+
+# Resistance types handled directly by the MIKE 1D engine's CalculateSpecificConveyance
+# (the engine-first path); the rest fall back to the Python implementation.
+RESISTANCE_TYPES_VIA_ENGINE = [ResistanceType.MANNINGS_M, ResistanceType.CHEZY]
+RESISTANCE_TYPES_VIA_FALLBACK = [
+    ResistanceType.RELATIVE,
+    ResistanceType.MANNINGS_N,
+    ResistanceType.DARCY_WEISBACH,
+]
+
+
+def make_cs_with_resistance(xz_data, resistance_type, value) -> CrossSection:
+    """Create an open cross section with a uniform resistance of the given type and value."""
+    x, z = xz_data
+    cs = CrossSection.from_xz(x=x, z=z, location_id="loc", chainage=100, topo_id="topo")
+    cs.resistance_type = resistance_type
+    df = cs.raw
+    df["resistance"] = value
+    cs.raw = df  # uniform distribution -> triggers recompute
+    return cs
+
+
 class TestCrossSectionUnits:
     """
     Unit tests for the CrossSection class.
@@ -296,9 +329,7 @@ class TestCrossSectionUnits:
         x, z = xz_data
 
         def conveyance_for(resistance_type, value):
-            cs = CrossSection.from_xz(
-                x=x, z=z, location_id="loc", chainage=100, topo_id="topo"
-            )
+            cs = CrossSection.from_xz(x=x, z=z, location_id="loc", chainage=100, topo_id="topo")
             cs.resistance_type = resistance_type
             df = cs.raw
             df["resistance"] = value
@@ -314,6 +345,88 @@ class TestCrossSectionUnits:
 
         # Non-equivalent resistances -> different conveyance.
         assert not np.allclose(mannings_n_50, mannings_m_50)
+
+    @pytest.mark.parametrize(
+        "resistance_type, value",
+        [
+            (ResistanceType.RELATIVE, 1.5),
+            (ResistanceType.MANNINGS_N, 0.03),
+            (ResistanceType.MANNINGS_M, 40.0),
+            (ResistanceType.CHEZY, 45.0),
+            (ResistanceType.DARCY_WEISBACH, 0.05),
+        ],
+    )
+    def test_conveyance_factor_formula_per_resistance_type(self, xz_data, resistance_type, value):
+        """The processed conveyance factor uses the correct formula for each resistance type.
+
+        Each formulation has its own conveyance formula (issue #229); using the wrong one
+        was the original bug. The expected values are computed from an explicit closed form
+        (CONVEYANCE_FORMULAS) rather than the implementation, so this is not circular. For
+        Darcy-Weisbach the processed resistance is stored as a Chezy number, which the
+        formula reads directly.
+        """
+        cs = make_cs_with_resistance(xz_data, resistance_type, value)
+        df = cs.processed
+        expected = CONVEYANCE_FORMULAS[resistance_type](
+            df.resistance.values, df.flow_area.values, df.radius.values
+        )
+        np.testing.assert_allclose(df.conveyance_factor, expected, rtol=1e-9, atol=1e-12)
+
+        # Conveyance must be positive wherever there is flow area.
+        flowing = df.flow_area.values > 0
+        assert (np.asarray(df.conveyance_factor)[flowing] > 0).all()
+
+    def test_conveyance_factor_distinguishes_resistance_types(self, xz_data):
+        """Resistance types must not collapse to the same conveyance (issue #229).
+
+        The original bug computed every formulation as if it were Manning's M, so Manning's n,
+        Manning's M and Chezy all produced identical conveyance for the same number. Here:
+        - Manning's n = 0.02 is hydraulically equivalent to Manning's M = 50 (M = 1/n) -> equal.
+        - The same number 50 under Manning's n, Chezy and Manning's M -> all different.
+        """
+        n_002 = make_cs_with_resistance(
+            xz_data, ResistanceType.MANNINGS_N, 0.02
+        ).processed.conveyance_factor
+        m_50 = make_cs_with_resistance(
+            xz_data, ResistanceType.MANNINGS_M, 50.0
+        ).processed.conveyance_factor
+        n_50 = make_cs_with_resistance(
+            xz_data, ResistanceType.MANNINGS_N, 50.0
+        ).processed.conveyance_factor
+        chezy_50 = make_cs_with_resistance(
+            xz_data, ResistanceType.CHEZY, 50.0
+        ).processed.conveyance_factor
+
+        # Manning's n = 0.02 is equivalent to Manning's M = 50 (M = 1/n).
+        np.testing.assert_allclose(n_002, m_50, rtol=1e-9)
+
+        # Same number, different formula -> different conveyance.
+        assert not np.allclose(n_50, m_50)
+        # Chezy uses sqrt(R) instead of R**(2/3) (the #229 "Type 3 shows no change" bug).
+        assert not np.allclose(chezy_50, m_50)
+        assert not np.allclose(chezy_50, n_50)
+
+    @pytest.mark.parametrize("resistance_type", RESISTANCE_TYPES_VIA_ENGINE)
+    def test_conveyance_factor_engine_matches_python(self, xz_data, resistance_type):
+        """For formulations the MIKE 1D engine supports, the engine result and the Python
+        fallback must agree, guarding against future divergence (issue #229)."""
+        cs = make_cs_with_resistance(xz_data, resistance_type, 45.0)
+        df = cs.processed
+        args = (df.resistance, df.flow_area, df.radius)
+        engine = cs._calculate_conveyance_factor_dotnet(*args)
+        assert engine is not None, "engine should support this formulation"
+        python = cs._calculate_conveyance_factor_python(*args)
+        np.testing.assert_allclose(engine, python, rtol=1e-9, atol=1e-12)
+
+    @pytest.mark.parametrize("resistance_type", RESISTANCE_TYPES_VIA_FALLBACK)
+    def test_conveyance_factor_uses_python_fallback(self, xz_data, resistance_type):
+        """Formulations the engine does not handle must fall back to the Python implementation
+        (the engine helper returns None), so the conveyance is still computed (issue #229)."""
+        value = 0.03 if resistance_type == ResistanceType.MANNINGS_N else 1.0
+        cs = make_cs_with_resistance(xz_data, resistance_type, value)
+        df = cs.processed
+        engine = cs._calculate_conveyance_factor_dotnet(df.resistance, df.flow_area, df.radius)
+        assert engine is None
 
     def test_processed_get(self, cs_sample):
         for cs in cs_sample:
@@ -449,7 +562,8 @@ class TestCrossSectionUnits:
     def test_raw_set_resistance_warns_zones_to_distributed(self, xns_basic):
         """Test that modifying resistance on ZONES cross section warns and casts to DISTRIBUTED."""
         zones_css = [
-            cs for cs in xns_basic.values()
+            cs
+            for cs in xns_basic.values()
             if cs.resistance_distribution == ResistanceDistribution.ZONES
         ]
         assert len(zones_css) > 0, "No ZONES cross sections found in testdata"
@@ -482,9 +596,7 @@ class TestCrossSectionUnits:
     def test_raw_set_resistance_distributed(self, xz_data):
         """Test that modifying distributed resistance via raw setter persists correctly."""
         x, z = xz_data
-        cs = CrossSection.from_xz(
-            x=x, z=z, location_id="loc1", chainage=100, topo_id="topo1"
-        )
+        cs = CrossSection.from_xz(x=x, z=z, location_id="loc1", chainage=100, topo_id="topo1")
         cs.resistance_distribution = ResistanceDistribution.DISTRIBUTED
         df = cs.raw
         df.resistance = np.arange(1, len(df) + 1, dtype=float)


### PR DESCRIPTION
## Problem

The processed `conveyance_factor` ignored the cross section's resistance type — Manning's n, Manning's M and Chézy all produced the same value for a given resistance number (#229). Chézy/Darcy-Weisbach also used the wrong exponent (`R**(2/3)` instead of `R**(1/2)`).

## Resolution

The conveyance factor now uses the correct formula per resistance type. Where possible the calculation is deferred to MIKE 1D's engine (`CalculateSpecificConveyance`), so it stays in sync with the engine and picks up any future formulation support. For formulations not reachable from Python — the public `CalculateSpecificConveyance` raises for them, and the routine that handles them all is an `internal` .NET implementation not exposed on MIKE 1D's public API — it falls back to a Python implementation.

Note this is not the *true* conveyance (which depends on slope and is computed by internal .NET implementations not reachable from Python). It is an estimate used to check monotonicity of the processed table, computed consistently with the MIKE+ cross section editor — see the [MIKE+ documentation](https://doc.mikepoweredbydhi.help/webhelp/2024/MIKEPlus/MIKEPlus/RiverNetwork_HydrModel/Processed_Data.htm).

Tests cover all resistance types relevant to open cross sections.

## Validation

In addition to the automated tests, cross sections were generated for each resistance formulation (Relative, Manning's n, Manning's M, Chézy, Darcy-Weisbach), saved to xns11, and opened manually in MIKE+ / MIKE Zero. The processed conveyance columns matched in all cases.

## Opportunity

MIKE 1D and MIKE+ each re-implement this estimate separately. Exposing a single shared routine on the MIKE 1D public API would let both — and in turn mikeio1d — share one implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)