### PR TITLE
Prepare v1.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,24 @@
 
 ### Removed
 
+## [1.3.0] - 2026-06-26
+
+This is primarily a maintenance release, bundling a few cross-section bug fixes and updated Python version support.
+
+### Added
+- Support for Python 3.14
+
+### Fixed
+- Cross-section conveyance now respects the resistance type, deferring computation to the MIKE 1D engine with a MIKE+ consistent fallback (#229).
+- Resistance values now persist correctly when set via the raw setter, including ZONES distribution (#233).
+- Datum is now applied to processed cross-section levels (#236).
+
+### Changed
+- Restructured package into a src/ layout (#243).
+
+### Removed
+- Support for Python 3.10 and 3.11. MIKE IO 1D now follows [Scientific Python SPEC 0](https://scientific-python.org/specs/spec-0000/) for the supported Python range (#238).
+
 ## [1.2.0] - 2026-05-20
 
 ### Added
@@ -296,7 +314,8 @@
 - Reading of res1d and xns11 files into pandas data frames
 
 
-[unreleased]: https://github.com/DHI/mikeio1d/compare/v1.2.0...HEAD
+[unreleased]: https://github.com/DHI/mikeio1d/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/DHI/mikeio1d/releases/tag/v1.3.0
 [1.2.0]: https://github.com/DHI/mikeio1d/releases/tag/v1.2.0
 [1.1.1]: https://github.com/DHI/mikeio1d/releases/tag/v1.1.1
 [1.1.0]: https://github.com/DHI/mikeio1d/releases/tag/v1.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = ["src/mikeio1d"]
 
 [project]
 name = "mikeio1d"
-version = "1.2.1"
+version = "1.3.0"
 description = "A package that uses the DHI MIKE1D .NET libraries to read res1d and xns11 files."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/mikeio1d/__init__.py
+++ b/src/mikeio1d/__init__.py
@@ -28,7 +28,7 @@ from .mikepath import MikePath
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.2.1"
+__version__ = "1.3.0"
 
 # UV may ignore requires-python upper bounds for local installs, potentially causing
 # compatibility issues with dependencies like 'pythonnet'. Adding this warning to help


### PR DESCRIPTION
## Summary

Prepares the **v1.3.0** release: bumps the version to `1.3.0` and documents the changes since `v1.2.1` in the changelog. This is primarily a maintenance release bundling a few cross-section bug fixes and updated Python version support.

## Changelog

### Added
- Support for Python 3.14

### Fixed
- Cross-section conveyance now respects the resistance type, deferring computation to the MIKE 1D engine with a MIKE+ consistent fallback (#229).
- Resistance values now persist correctly when set via the raw setter, including ZONES distribution (#233).
- Datum is now applied to processed cross-section levels (#236).

### Changed
- Restructured package into a src/ layout (#243).

### Removed
- Support for Python 3.10 and 3.11. MIKE IO 1D now follows [Scientific Python SPEC 0](https://scientific-python.org/specs/spec-0000/) for the supported Python range (#238).

## Notes
- `v1.2.1` was a packaging-only release (uv migration / build hooks) with no changelog entry, so this entry covers everything substantive since `v1.2.1`.
- The LTS datetime read fix (#232) is intentionally **not** listed — that fix shipped in `v1.2.1`; the recent PR only added a regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
