### PR TITLE
Prepare v1.3.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@
 
 ### Removed
 
+## [1.3.1] - 2026-07-15
+
+### Fixed
+- Reading PRF files containing pumps with IDs differing only by case (e.g. `my_pump` and `MY_PUMP`) no longer crashes (#245).
+
 ## [1.3.0] - 2026-06-26
 
 This is primarily a maintenance release, bundling a few cross-section bug fixes and updated Python version support.
@@ -314,7 +319,8 @@ This is primarily a maintenance release, bundling a few cross-section bug fixes 
 - Reading of res1d and xns11 files into pandas data frames
 
 
-[unreleased]: https://github.com/DHI/mikeio1d/compare/v1.3.0...HEAD
+[unreleased]: https://github.com/DHI/mikeio1d/compare/v1.3.1...HEAD
+[1.3.1]: https://github.com/DHI/mikeio1d/releases/tag/v1.3.1
 [1.3.0]: https://github.com/DHI/mikeio1d/releases/tag/v1.3.0
 [1.2.0]: https://github.com/DHI/mikeio1d/releases/tag/v1.2.0
 [1.1.1]: https://github.com/DHI/mikeio1d/releases/tag/v1.1.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ packages = ["src/mikeio1d"]
 
 [project]
 name = "mikeio1d"
-version = "1.3.0"
+version = "1.3.1"
 description = "A package that uses the DHI MIKE1D .NET libraries to read res1d and xns11 files."
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/src/mikeio1d/__init__.py
+++ b/src/mikeio1d/__init__.py
@@ -28,7 +28,7 @@ from .mikepath import MikePath
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 
 # UV may ignore requires-python upper bounds for local installs, potentially causing
 # compatibility issues with dependencies like 'pythonnet'. Adding this warning to help


### PR DESCRIPTION
## Summary
- Bump version to 1.3.1 in `pyproject.toml` and `src/mikeio1d/__init__.py`
- Document the fix for PRF files with case-colliding pump IDs crashing on read (#245) in the changelog

## Test plan
- [ ] CI passes