### PR TITLE
docs: fix typos and copy-paste errors in docstrings

### DIFF
--- a/src/mikeio1d/result_network/result_gridpoint.py
+++ b/src/mikeio1d/result_network/result_gridpoint.py
@@ -27,7 +27,7 @@ class ResultGridPoint(ResultLocation):
     ----------
     reach: IRes1DReach
         MIKE 1D IRes1DReach object.
-    gridpoint IRes1DGridPoint
+    gridpoint : IRes1DGridPoint
         MIKE 1D IRes1DGridPoint object.
     data_items : list of IDataItem objects
         A list of IDataItem objects (vector data object) the
@@ -153,7 +153,7 @@ class ResultGridPointCreator(ResultLocationCreator):
         Instance of ResultGridPoint, which the ResultGridPointCreator deals with.
     reach: IRes1DReach
         MIKE 1D IRes1DReach object.
-    gridpoint IRes1DGridPoint
+    gridpoint : IRes1DGridPoint
         MIKE 1D IRes1DGridPoint object.
     data_items : list of IDataItem objects
         A list of IDataItem objects (vector data object) the
@@ -166,7 +166,7 @@ class ResultGridPointCreator(ResultLocationCreator):
     Attributes
     ----------
     structure_data_items : list of IDataItem object.
-        List of IDataItem objects belonging to a structures
+        List of IDataItem objects belonging to structures
         defined on the current grid point.
 
     """

--- a/src/mikeio1d/result_network/result_network.py
+++ b/src/mikeio1d/result_network/result_network.py
@@ -47,7 +47,7 @@ class ResultNetwork:
     queue: list
         A list of TimeSeriesId objects to be used when calling res1D.read().
     nodes : ResultNodes object
-        Is is a wrapper class object for all ResultData nodes.
+        It is a wrapper class object for all ResultData nodes.
     reaches : ResultReaches object
         Is a wrapper class object for all ResultData reaches.
     catchments : ResultCatchments object

--- a/src/mikeio1d/result_network/result_quantity.py
+++ b/src/mikeio1d/result_network/result_quantity.py
@@ -102,7 +102,7 @@ class ResultQuantity:
 
     @property
     def name(self) -> str:
-        """Name of the quantity id assosciated with collection."""
+        """Name of the quantity id associated with collection."""
         return self._name
 
     def add(self):

--- a/src/mikeio1d/result_network/result_structure.py
+++ b/src/mikeio1d/result_network/result_structure.py
@@ -90,7 +90,7 @@ class ResultStructure(ResultLocation):
         """Get IRes1DDataSet object associated with ResultStructure.
 
         This is the reach IRes1DDataSet object because ResultStructure objects do not
-        have a corresonding IRes1DDataSet object.
+        have a corresponding IRes1DDataSet object.
 
         Parameters
         ----------
@@ -123,15 +123,15 @@ class ResultStructure(ResultLocation):
 
 
 class ResultStructureCreator(ResultLocationCreator):
-    """Helper class for creating ResultGridPoint.
+    """Helper class for creating ResultStructure.
 
     Parameters
     ----------
-    result_location : ResultGridPoint
-        Instance of ResultGridPoint, which the ResultGridPointCreator deals with.
+    result_location : ResultStructure
+        Instance of ResultStructure, which the ResultStructureCreator deals with.
     reach: IRes1DReach
         MIKE 1D IRes1DReach object.
-    gridpoint IRes1DGridPoint
+    gridpoint : IRes1DGridPoint
         MIKE 1D IRes1DGridPoint object.
     data_items : list of IDataItem objects
         A list of IDataItem objects (vector data object) the
@@ -144,7 +144,7 @@ class ResultStructureCreator(ResultLocationCreator):
     Attributes
     ----------
     structure_data_items : list of IDataItem object.
-        List of IDataItem objects belonging to a structures
+        List of IDataItem objects belonging to structures
         defined on the current grid point.
 
     """
@@ -164,7 +164,7 @@ class ResultStructureCreator(ResultLocationCreator):
         self.data_items_dict: dict[str, IDataItem] = {}
 
     def create(self):
-        """Perform ResultGridPoint creation steps."""
+        """Perform ResultStructure creation steps."""
         for data_item in self.data_items_intial:
             self.add_res1d_structure_data_item(data_item)
 


### PR DESCRIPTION
## Summary

Docstring-only fixes: 11 typos, numpydoc formatting slips, and copy-paste leftovers. No code, no identifiers, no behaviour changes.

**src/mikeio1d/result_network/result_gridpoint.py**
- `gridpoint IRes1DGridPoint` -> `gridpoint : IRes1DGridPoint` (2x) - the ` : ` separator was missing, so numpydoc does not parse these as parameter entries (the repo sets `lint.pydocstyle.convention = "numpy"`)
- `belonging to a structures` -> `belonging to structures`

**src/mikeio1d/result_network/result_structure.py**
- `corresonding` -> `corresponding`
- `gridpoint IRes1DGridPoint` -> `gridpoint : IRes1DGridPoint`
- `belonging to a structures` -> `belonging to structures`
- The `ResultStructureCreator` docstring was copy-pasted from `ResultGridPointCreator` and still referred to the wrong class:
  - `Helper class for creating ResultGridPoint.` -> `Helper class for creating ResultStructure.`
  - `result_location : ResultGridPoint` -> `result_location : ResultStructure` (matches the `__init__` annotation)
  - `Instance of ResultGridPoint, which the ResultGridPointCreator deals with.` -> `Instance of ResultStructure, which the ResultStructureCreator deals with.`
  - `Perform ResultGridPoint creation steps.` -> `Perform ResultStructure creation steps.`

**src/mikeio1d/result_network/result_quantity.py**
- `assosciated` -> `associated`

**src/mikeio1d/result_network/result_network.py**
- `Is is a wrapper class object` -> `It is a wrapper class object`

### Left for you to decide

- `ResultStructureCreator`'s `Parameters` block still documents `gridpoint` and `result_reach`, but `__init__` only takes `(result_location, reach, data_items, res1d)` - more copy-paste from `ResultGridPointCreator`. I have not removed those entries, since deleting documented parameters felt like your call rather than a typo fix.
- `ResultStructureCreator.__init__` sets `self.data_items_intial` (should be `initial`), read back in `create()`. That is an attribute rename rather than a doc fix, so it is not in this PR.